### PR TITLE
"View in explorer" tooltip fix

### DIFF
--- a/src/_main.scss
+++ b/src/_main.scss
@@ -94,8 +94,7 @@ video {
 
 *[tooltip]:hover:before {
     border-radius: 4px;
-    /*left: 0;*/
-    left: 10%;
+    left: 60px;
     transform: translateX(-50%);
     content: attr(tooltip);
     position: absolute;

--- a/src/_main.scss
+++ b/src/_main.scss
@@ -95,7 +95,7 @@ video {
 *[tooltip]:hover:before {
     border-radius: 4px;
     /*left: 0;*/
-    left: 0;
+    left: 10%;
     transform: translateX(-50%);
     content: attr(tooltip);
     position: absolute;

--- a/src/components/wallet/activity/TxRow.vue
+++ b/src/components/wallet/activity/TxRow.vue
@@ -191,6 +191,7 @@ export default class TxRow extends Vue {
 }
 
 .explorer_col {
+    position: relative;
     a {
         color: var(--primary-color);
         opacity: 0.4;


### PR DESCRIPTION
This PR fixes a problem where tooltip was clipped. Moved the tooltip to the viewport

Before:
![image](https://user-images.githubusercontent.com/34208222/181178842-743d0215-4cf1-4417-915d-b832da86372e.png)

After:
![image](https://user-images.githubusercontent.com/34208222/181178586-63299df7-9260-43db-9103-c936af6aa119.png)
