### PR TITLE
Build Docker on push[c4t,dev] and workflow_dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,13 @@ on:
   push:
     tags:        
       - v*
-  pull_request:
     branches: [chain4travel,dev]
+  workflow_dispatch:
+    inputs:
+      wd_branch:
+        description: 'camino-wallet branch'
+        required: true
+        default: 'dev'
 
 jobs:
   docker-build:
@@ -14,9 +19,16 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '15'
+      - id: branchVars
+        run: |
+          if [[ "${{ github.event_name" != "workflow_dispatch" }} ]]; then
+              echo "branch=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=${{ github.event.inputs.wd_branch }}" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ steps.branchVars.outputs.branch }}
           fetch-depth: 0
       - uses: docker/login-action@v2
         name: Login to DockerHub


### PR DESCRIPTION
## Build Docker on push[c4t,dev] and workflow_dispatch
The changes in last PR (#29) doesn't trigger docker build on PR merge.

- Trigger docker container on every push of c4t / dev branch)
- Introduce worflow_dispatch, which triggers a build on demand