### PR TITLE
Enable workflow_dispatch events on docker push action for independent builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,6 @@
 name: build-app
-on: [push]
+on: [push, workflow_dispatch]
+
 jobs:
   yarn-build:
     runs-on: ubuntu-latest
@@ -76,4 +77,4 @@ jobs:
             ${{ steps.setTagVariables.outputs.branch }}
             c4tplatform/camino-wallet:${{ needs.bump-version.outputs.version }}
             ${{ steps.setTagVariables.outputs.stable }}
-          push: ${{ github.ref == 'refs/heads/chain4travel' || github.ref == 'refs/heads/dev' }}
+          push: ${{ github.ref == 'refs/heads/chain4travel' || github.ref == 'refs/heads/dev' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
For easier image creation of specific branches, this PR setup listening for `workflow_dispatch` events and allows to push on demand. 
