### PR TITLE
[BUILD] Change submodule branch to dist / checkout recorded SHA

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "camino-wallet-sdk"]
 	path = camino-wallet-sdk
 	url = https://github.com/chain4travel/camino-wallet-sdk.git
-	branch = dev-dist
+	branch = dist

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "test_watch": "jest --verbose --watch ./tests",
         "test_debug": "node --inspect-brk node_modules/.bin/jest ./tests --runInBand",
         "test": "jest --verbose ./tests",
-        "preinstall": "git submodule update --init --recursive --remote"
+        "preinstall": "git submodule update --recursive --init"
     },
     "dependencies": {
         "@arcblock/forge-util": "^1.6.3",


### PR DESCRIPTION
## Change submodule branch to dist / checkout recorded SHA
With this PR only dist branch is used for dev and c4t branch to provide camino-wallet-sdk dependency.
Checkout SHA is the recorded submodule SHA in this repo