### PR TITLE
Add C-Chain key to HDWallet / RegisterNode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  push:branches-ignore: [chain4travel, dev]
 
 env:
   CI: true
@@ -20,3 +20,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn install
       - run: yarn lint
+      - run: yarn format-check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
           CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
       - name: linting
         run: yarn run lint
+      - name: prettier
+        run: yarn run format-check
       - name: jest-run
         run: yarn test
       - name: cypress-run

--- a/.github/workflows/update_gcs_buckets.yml
+++ b/.github/workflows/update_gcs_buckets.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-        - chain4travel
-        - dev
+      - chain4travel
+      - dev
 
 env:
   node_version: 15
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.node_version }}
-          
-      - name: install yarn dependencies        
+
+      - name: install yarn dependencies
         run: yarn install
       - name: build
         run: yarn build
@@ -37,7 +37,7 @@ jobs:
 
         uses: 'google-github-actions/auth@v1'
         with:
-            credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
 
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
@@ -45,9 +45,7 @@ jobs:
       - name: update bucket files
         run: gsutil rsync -R -d dist gs://${{ steps.setBucketNames.outputs.bucket }}
 
-## TODO: this needs more discussion, to decide if we really need 3 different deployments from 2 branch for the wallet and explorer
+      ## TODO: this needs more discussion, to decide if we really need 3 different deployments from 2 branch for the wallet and explorer
       - name: update bucket files for columbus
         if: ${{ github.ref == 'refs/heads/chain4travel' }}
         run: gsutil rsync -R -d dist gs://wallet.columbus.camino.network
-
-     

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "build": "vue-cli-service build",
         "cypress": "cypress run",
         "format": "prettier src/**/*.{js,ts,vue} .github/workflows/*.yml --write",
+        "format-check": "prettier src/**/*.{js,ts,vue} .github/workflows/*.yml --check",
         "lint": "vue-cli-service lint",
         "release": "release-it",
         "serve": "vue-cli-service serve",

--- a/src/js/HdHelper.ts
+++ b/src/js/HdHelper.ts
@@ -38,6 +38,8 @@ class HdHelper {
     }
     changePath: string
     masterKey: HDKey
+    ethKeyPair: AVMKeyPair | PlatformVMKeyPair | undefined
+    ethAddress: string
     hdIndex: number
     utxoSet: AVMUTXOSet | PlatformUTXOSet
     isPublic: boolean
@@ -47,6 +49,7 @@ class HdHelper {
     constructor(
         changePath: string,
         masterKey: HDKey,
+        ethKey?: HDKey,
         chainId: ChainAlias = 'X',
         isPublic: boolean = false
     ) {
@@ -70,6 +73,14 @@ class HdHelper {
         this.masterKey = masterKey
         this.hdIndex = 0
         this.isPublic = isPublic
+        this.ethKeyPair = undefined
+        this.ethAddress = ''
+
+        if (ethKey) {
+            let addrBuf = AVMKeyPair.addressFromPublicKey(Buffer.from(ethKey.publicKey))
+            this.ethAddress = bintools.addressToString(hrp, chainId, addrBuf)
+            this.ethKeyPair = this.keyChain.importKey(Buffer.from(ethKey.privateKey))
+        }
         // this.oninit()
     }
 
@@ -91,6 +102,8 @@ class HdHelper {
             this.utxoSet = new PlatformUTXOSet()
         }
         this.hdIndex = 0
+        this.addressCache = {}
+        this.keyCache = {}
         await this.oninit()
     }
 
@@ -195,6 +208,7 @@ class HdHelper {
         } else {
             keychain = new PlatformVMKeyChain(hrp, this.chainId)
         }
+        if (this.ethKeyPair) keychain.addKey(this.ethKeyPair)
 
         for (let i: number = 0; i <= this.hdIndex; i++) {
             let key: AVMKeyPair | PlatformVMKeyPair
@@ -216,7 +230,7 @@ class HdHelper {
 
     // Returns all key pairs up to hd index
     getAllDerivedKeys(upTo = this.hdIndex): AVMKeyPair[] | PlatformVMKeyPair[] {
-        let set: AVMKeyPair[] | PlatformVMKeyPair[] = []
+        let set: AVMKeyPair[] | PlatformVMKeyPair[] = this.ethKeyPair ? [this.ethKeyPair] : []
         for (var i = 0; i <= upTo; i++) {
             if (this.chainId === 'X') {
                 let key = this.getKeyForIndex(i) as AVMKeyPair
@@ -230,7 +244,7 @@ class HdHelper {
     }
 
     getAllDerivedAddresses(upTo = this.hdIndex, start = 0): string[] {
-        let res = []
+        let res = this.ethKeyPair ? [this.ethAddress] : []
         for (var i = start; i <= upTo; i++) {
             let addr = this.getAddressForIndex(i)
             res.push(addr)

--- a/src/js/TxHelper.ts
+++ b/src/js/TxHelper.ts
@@ -50,9 +50,13 @@ export async function buildUnsignedTransaction(
     const AVAX_ID_STR = AVAX_ID_BUF.toString('hex')
     const TO_BUF = bintools.stringToAddress(addr)
 
-    const aad: AssetAmountDestination = new AssetAmountDestination([TO_BUF], fromAddrs, [
-        changeAddr,
-    ])
+    const aad: AssetAmountDestination = new AssetAmountDestination(
+        [TO_BUF],
+        1,
+        fromAddrs,
+        [changeAddr],
+        1
+    )
     const ZERO = new BN(0)
     let isFeeAdded = false
 

--- a/src/js/wallets/HdWalletCore.ts
+++ b/src/js/wallets/HdWalletCore.ts
@@ -29,9 +29,9 @@ abstract class HdWalletCore extends WalletCore {
         super()
         this.ethHdNode = ethHdNode
         this.chainId = ava.XChain().getBlockchainAlias() || ava.XChain().getBlockchainID()
-        this.externalHelper = new HdHelper('m/0', accountHdKey, undefined, isPublic)
-        this.internalHelper = new HdHelper('m/1', accountHdKey, undefined, isPublic)
-        this.platformHelper = new HdHelper('m/0', accountHdKey, 'P', isPublic)
+        this.externalHelper = new HdHelper('m/0', accountHdKey, ethHdNode, undefined, isPublic)
+        this.internalHelper = new HdHelper('m/1', accountHdKey, undefined, undefined, isPublic)
+        this.platformHelper = new HdHelper('m/0', accountHdKey, ethHdNode, 'P', isPublic)
 
         this.externalHelper.oninit().then((res) => {
             this.updateInitState()

--- a/src/js/wallets/LedgerWallet.ts
+++ b/src/js/wallets/LedgerWallet.ts
@@ -692,7 +692,9 @@ class LedgerWallet extends HdWalletCore implements AvaWalletCore {
         return signedTx
     }
 
-    async signP(unsignedTx: PlatformUnsignedTx): Promise<PlatformTx> {
+    async signP(unsignedTx: PlatformUnsignedTx, additionalSigners?: string[]): Promise<PlatformTx> {
+        if (additionalSigners?.length) throw 'AdditionalSigners not supported.'
+
         let tx = unsignedTx.getTransaction()
         let txType = tx.getTxType()
         let chainId: ChainIdType = 'P'

--- a/src/js/wallets/MnemonicWallet.ts
+++ b/src/js/wallets/MnemonicWallet.ts
@@ -242,8 +242,14 @@ export default class MnemonicWallet extends HdWalletCore implements IAvaHdWallet
         return tx
     }
 
-    async signP(unsignedTx: PlatformUnsignedTx): Promise<PlatformTx> {
+    async signP(unsignedTx: PlatformUnsignedTx, additionalSigners?: string[]): Promise<PlatformTx> {
         let keychain = this.platformHelper.getKeychain() as PlatformVMKeyChain
+
+        if (additionalSigners?.length) {
+            keychain = keychain.clone()
+            additionalSigners.forEach((k) => keychain.importKey(k))
+        }
+
         const tx = unsignedTx.sign(keychain)
         return tx
     }

--- a/src/js/wallets/SingletonWallet.ts
+++ b/src/js/wallets/SingletonWallet.ts
@@ -250,8 +250,14 @@ class SingletonWallet extends WalletCore implements AvaWalletCore, UnsafeWallet 
         return tx
     }
 
-    async signP(unsignedTx: PlatformUnsignedTx): Promise<PlatformTx> {
+    async signP(unsignedTx: PlatformUnsignedTx, additionalSigners?: string[]): Promise<PlatformTx> {
         let keychain = this.platformKeyChain
+
+        if (additionalSigners?.length) {
+            keychain = keychain.clone()
+            additionalSigners.forEach((k) => keychain.importKey(k))
+        }
+
         const tx = unsignedTx.sign(keychain)
         return tx
     }

--- a/src/js/wallets/WalletCore.ts
+++ b/src/js/wallets/WalletCore.ts
@@ -46,7 +46,10 @@ abstract class WalletCore {
 
     abstract signC(unsignedTx: EVMUnsignedTx): Promise<EVMTx>
     abstract signX(unsignedTx: AVMUnsignedTx): Promise<AVMTx>
-    abstract signP(unsignedTx: PlatformUnsignedTx): Promise<PlatformTx>
+    abstract signP(
+        unsignedTx: PlatformUnsignedTx,
+        additionalSigners?: string[]
+    ): Promise<PlatformTx>
 
     abstract signMessage(msg: string, address?: string): Promise<string>
     abstract getPlatformUTXOSet(): PlatformUTXOSet

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,7 +891,7 @@
 "@c4tplatform/camino-wallet-sdk@file:camino-wallet-sdk":
   version "0.0.2"
   dependencies:
-    "@c4tplatform/caminojs" "file:C:/Users/mpfau/AppData/Local/Yarn/Cache/v6/npm-@c4tplatform-camino-wallet-sdk-0.0.2-cc32d5c8-4692-487d-8676-9ab8597f9b19-1669277075513/node_modules/@c4tplatform/camino-wallet-sdk/caminojs"
+    "@c4tplatform/caminojs" "file:C:/Users/mpfau/AppData/Local/Yarn/Cache/v6/npm-@c4tplatform-camino-wallet-sdk-0.0.2-f95cda17-5ae8-40cb-af18-e46c341e74bf-1673852857218/node_modules/@c4tplatform/camino-wallet-sdk/caminojs"
     "@ethereumjs/tx" "3.4.0"
     "@ledgerhq/hw-app-eth" "6.12.2"
     "@ledgerhq/hw-transport" "^6.19.0"
@@ -14548,11 +14548,6 @@ rlp@^2.2.3, rlp@^2.2.4:
   integrity sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==
   dependencies:
     bn.js "^4.11.1"
-
-roboto-fontface@0.10.0:
-  version "0.10.0"
-  resolved "https://registry.npmjs.org/roboto-fontface/-/roboto-fontface-0.10.0.tgz"
-  integrity sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g==
 
 rsvp@^4.8.4:
   version "4.8.5"


### PR DESCRIPTION
## Wallet Upgrades
### HD Wallet
- Add c-chain privateKey to keychain to be able to view / sign kyc / consortium tx
### General
- Implement RegisterNodeTx, which requires NodeSignature (PrivateKey) to be passed.
Ledger wallet is not supported because of the additional signature.