### PR TITLE
Fix P balance refresh, move depositAndBond flag to Network state

### DIFF
--- a/src/components/wallet/TopCards/BalanceCard/BalanceCard.vue
+++ b/src/components/wallet/TopCards/BalanceCard/BalanceCard.vue
@@ -44,7 +44,7 @@
                         <label>{{ $t('top.locked') }}</label>
                         <p>{{ balanceTextLocked }} {{ nativeAssetSymbol }}</p>
                     </div>
-                    <div v-if="!depositAndBound">
+                    <div v-if="!depositAndBond">
                         <label>{{ $t('top.balance.stake') }}</label>
                         <p>{{ stakingText }} {{ nativeAssetSymbol }}</p>
                     </div>
@@ -58,7 +58,7 @@
                         <label>{{ $t('top.balance.available') }} (C)</label>
                         <p>{{ evmUnlocked | cleanAvaxBN }} {{ nativeAssetSymbol }}</p>
                     </div>
-                    <div v-if="depositAndBound">
+                    <div v-if="depositAndBond">
                         <label>{{ $t('top.balance.deposited') }} (P)</label>
                         <p>{{ platformDeposited | cleanAvaxBN }} {{ nativeAssetSymbol }}</p>
                         <label>{{ $t('top.balance.bonded') }} (P)</label>
@@ -74,7 +74,7 @@
                         <label>{{ $t('top.balance.locked_stake') }} (P)</label>
                         <p>{{ platformLockedStakeable | cleanAvaxBN }} {{ nativeAssetSymbol }}</p>
                     </div>
-                    <div v-if="!depositAndBound">
+                    <div v-if="!depositAndBond">
                         <label>{{ $t('top.balance.stake') }}</label>
                         <p>{{ stakingText }} {{ nativeAssetSymbol }}</p>
                     </div>
@@ -118,26 +118,20 @@ import { ava } from '@/AVA'
 export default class BalanceCard extends Vue {
     isBreakdown = false
     intervalId: NodeJS.Timeout | number | null = null
-    depositAndBound: Boolean =
-        ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
     $refs!: {
         utxos_modal: UtxosBreakdownModal
     }
 
     mounted() {
-        if (this.depositAndBound) this.$store.dispatch('Assets/getPChainBalances')
-    }
-
-    @Watch('$store.state.Network.selectedNetwork.networkId')
-    SupportdepositAndBound(): void {
-        this.depositAndBound =
-            ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
+        if (this.depositAndBond) this.$store.dispatch('Assets/getPChainBalances')
     }
 
     updateBalance(): void {
         this.$store.dispatch('Assets/updateUTXOs')
         this.$store.dispatch('History/updateTransactionHistory')
-        if (this.depositAndBound) this.$store.dispatch('Assets/getPChainBalances')
+        if (this.depositAndBond) {
+            this.$store.dispatch('Assets/getPChainBalances')
+        }
     }
 
     showUTXOsModal() {
@@ -151,6 +145,10 @@ export default class BalanceCard extends Vue {
     get ava_asset(): AvaAsset | null {
         let ava = this.$store.getters['Assets/AssetAVA']
         return ava
+    }
+
+    get depositAndBond(): boolean {
+        return this.$store.getters['Network/depositAndBond']
     }
 
     get avmUnlocked(): BN {
@@ -244,7 +242,7 @@ export default class BalanceCard extends Vue {
         if (this.isUpdateBalance) return '--'
 
         if (this.ava_asset !== null) {
-            if (this.depositAndBound) {
+            if (this.depositAndBond) {
                 let denomination = this.ava_asset.denomination
                 let total = this.platformDeposited
                     .add(this.platformBonded)
@@ -268,7 +266,7 @@ export default class BalanceCard extends Vue {
     }
 
     get platformUnlocked(): BN {
-        if (this.depositAndBound) return this.$store.getters['Assets/walletPlatformBalanceUnlocked']
+        if (this.depositAndBond) return this.$store.getters['Assets/walletPlatformBalanceUnlocked']
         else return this.$store.getters['Assets/walletPlatformBalance']
     }
 

--- a/src/components/wallet/earn/ChainTransfer/ChainTransfer.vue
+++ b/src/components/wallet/earn/ChainTransfer/ChainTransfer.vue
@@ -177,8 +177,6 @@ export default class ChainTransfer extends Vue {
     importState: TxState = TxState.waiting
     importStatus: string | null = null
     importReason: string | null = null
-    depositAndBound: Boolean =
-        ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
 
     @Watch('sourceChain')
     @Watch('targetChain')
@@ -186,12 +184,6 @@ export default class ChainTransfer extends Vue {
         if (this.sourceChain === 'C' || this.targetChain === 'C') {
             this.updateBaseFee()
         }
-    }
-
-    @Watch('$store.state.Network.selectedNetwork.networkId')
-    SupportdepositAndBound(): void {
-        this.depositAndBound =
-            ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
     }
 
     created() {
@@ -204,12 +196,18 @@ export default class ChainTransfer extends Vue {
     }
 
     get platformUnlocked(): BN {
-        if (this.depositAndBound) return this.$store.getters['Assets/walletPlatformBalanceUnlocked']
+        if (this.depositAndBond) {
+            return this.$store.getters['Assets/walletPlatformBalanceUnlocked']
+        }
         return this.$store.getters['Assets/walletPlatformBalance']
     }
 
     get platformLocked(): BN {
         return this.$store.getters['Assets/walletPlatformBalanceLocked']
+    }
+
+    get depositAndBond(): boolean {
+        return this.$store.getters['Network/depositAndBond']
     }
 
     get avmUnlocked(): BN {
@@ -558,7 +556,9 @@ export default class ChainTransfer extends Vue {
         setTimeout(() => {
             this.$store.dispatch('Assets/updateUTXOs')
             this.$store.dispatch('History/updateTransactionHistory')
-            if (this.depositAndBound) this.$store.dispatch('Assets/getPChainBalances')
+            if (this.depositAndBond) {
+                this.$store.dispatch('Assets/getPChainBalances')
+            }
         }, BALANCE_DELAY)
     }
 

--- a/src/store/modules/assets/assets.ts
+++ b/src/store/modules/assets/assets.ts
@@ -43,6 +43,7 @@ import MnemonicWallet from '@/js/wallets/MnemonicWallet'
 import { LedgerWallet } from '@/js/wallets/LedgerWallet'
 import { getPayloadFromUTXO } from '@/helpers/helper'
 import { isUrlBanned } from '@/components/misc/NftPayloadView/blacklist'
+import store from '@/store'
 
 const assets_module: Module<AssetsState, RootState> = {
     namespaced: true,
@@ -523,8 +524,7 @@ const assets_module: Module<AssetsState, RootState> = {
             // @ts-ignore
             let assetsDict: AssetsDict = state.assetsDict
             let res: IWalletAssetsDict = {}
-            let supportBond =
-                ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
+            let depositAndBond = store.getters['Network/depositAndBond']
 
             for (var assetId in assetsDict) {
                 let balanceAmt = balanceDict[assetId]
@@ -543,7 +543,7 @@ const assets_module: Module<AssetsState, RootState> = {
                 // Add extras for Native token
                 // @ts-ignore
                 if (asset.id === state.AVA_ASSET_ID) {
-                    if (supportBond) {
+                    if (depositAndBond) {
                         asset.addExtra(getters.walletPlatformBalance)
                         asset.addExtra(getters.walletPlatformBalanceLocked)
                         asset.addExtra(getters.walletPlatformBalanceLockedStakeable)

--- a/src/store/modules/network/network.ts
+++ b/src/store/modules/network/network.ts
@@ -18,6 +18,7 @@ const network_module: Module<NetworkState, RootState> = {
         networksCustom: [],
         selectedNetwork: null,
         txFee: new BN(0),
+        depositAndBond: false,
     },
     mutations: {
         addNetwork(state, net: AvaNetwork) {
@@ -27,6 +28,9 @@ const network_module: Module<NetworkState, RootState> = {
     getters: {
         allNetworks(state) {
             return state.networks.concat(state.networksCustom)
+        },
+        depositAndBond(state) {
+            return state.depositAndBond
         },
     },
     actions: {
@@ -120,6 +124,9 @@ const network_module: Module<NetworkState, RootState> = {
             state.selectedNetwork = net
             dispatch('saveSelectedNetwork')
 
+            state.depositAndBond =
+                ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
+
             // Update explorer api
             explorer_api.defaults.baseURL = net.explorerUrl
 
@@ -146,13 +153,14 @@ const network_module: Module<NetworkState, RootState> = {
             await dispatch('Assets/onNetworkChange', net, { root: true })
             await dispatch('Launch/onNetworkChange', net, { root: true })
             dispatch('Assets/updateUTXOs', null, { root: true })
+            if (state.depositAndBond) {
+                dispatch('Assets/getPChainBalances', null, { root: true })
+            }
             dispatch('Platform/update', null, { root: true })
             dispatch('Platform/updateMinStakeAmount', null, { root: true })
             dispatch('updateTxFee')
             // Update tx history
             dispatch('History/updateTransactionHistory', null, { root: true })
-            if (ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature)
-                dispatch('Assets/getPChainBalances')
 
             // Set the SDK Network
             setAvalanche(ava)

--- a/src/store/modules/network/types.ts
+++ b/src/store/modules/network/types.ts
@@ -9,6 +9,8 @@ export interface NetworkState {
     status: NetworkStatus
 
     txFee: BN
+
+    depositAndBond: boolean
 }
 
 export type NetworkStatus = 'disconnected' | 'connecting' | 'connected'

--- a/src/views/wallet/Validator.vue
+++ b/src/views/wallet/Validator.vue
@@ -27,8 +27,7 @@
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Vue, Component, Watch } from 'vue-property-decorator'
-import { ava } from '@/AVA'
+import { Component, Vue } from 'vue-property-decorator'
 import AddValidator from '@/components/wallet/earn/Validate/AddValidator.vue'
 import { BN } from '@c4tplatform/caminojs/dist'
 import { bnToBig } from '@/helpers/helper'
@@ -54,15 +53,6 @@ export default class Validator extends Vue {
     isConsortiumMember = false
     isNodeRegistered = false
     intervalID: any = null
-    depositAndBond: Boolean =
-        ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
-
-    @Watch('$store.state.Network.selectedNetwork.networkId')
-    onNetworkChange() {
-        this.$forceUpdate()
-        this.depositAndBond =
-            ava.getNetwork().P.lockModeBondDeposit && ava.getNetwork().P.verifyNodeSignature
-    }
 
     updateValidators() {
         this.$store.dispatch('Platform/update')
@@ -106,6 +96,10 @@ export default class Validator extends Vue {
         return this.$store.state.Platform.minStake
     }
 
+    get depositAndBond(): boolean {
+        return this.$store.getters['Network/depositAndBond']
+    }
+
     get platformLockedStakeable(): BN {
         // return this.$store.getters.walletPlatformBalanceLockedStakeable
         return this.$store.getters['Assets/walletPlatformBalanceLockedStakeable']
@@ -116,7 +110,9 @@ export default class Validator extends Vue {
     }
 
     get totBal(): BN {
-        if (this.depositAndBond) return this.platformUnlocked.add(this.platformTotalLocked)
+        if (this.depositAndBond) {
+            return this.platformUnlocked.add(this.platformTotalLocked)
+        }
         return this.platformUnlocked.add(this.platformLockedStakeable)
     }
 
@@ -146,6 +142,7 @@ export default class Validator extends Vue {
 </script>
 <style scoped lang="scss">
 @use '../../styles/main';
+
 /* body {
     height: auto;
     overflow: auto !important;
@@ -154,11 +151,14 @@ export default class Validator extends Vue {
     display: grid;
     grid-template-rows: max-content 1fr;
 }
+
 .header {
     margin-bottom: 1rem;
+
     h1 {
         font-weight: normal;
     }
+
     display: flex;
     /*justify-content: space-between;*/
     /*align-items: center;*/
@@ -180,9 +180,11 @@ export default class Validator extends Vue {
         }
     }
 }
+
 .wrong_network {
     color: var(--primary-color-light);
 }
+
 .options {
     margin: 30px 0;
     display: grid;


### PR DESCRIPTION
This PR fixes an issue when P-chain balance wasn't refreshing correctly after switching networks. It also moves depositAndBond to Network state, so it can be used in multiple places in the app and not queried every single time.