### PR TITLE
fix typo

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -77,8 +77,7 @@
             "studio": "Studio",
             "advanced": "Advanced",
             "activity": "Activity",
-            "launch": "Launch",
-            "validator": "Validator"
+            "launch": "Launch"
         },
         "address_card": {},
         "collectibles": {
@@ -178,7 +177,7 @@
                 "desc": "Transaction Sent",
                 "label1": "Transaction Hash"
             },
-            "reset": "Start Again"
+            "reset": "New Transaction”"
         }
     },
     "cross_chain": {
@@ -424,7 +423,7 @@
                 "export": "Export Transaction ID:",
                 "import": "Import Transaction ID:",
                 "message": "You have successfully transferred between chains.",
-                "again": "Start Again",
+                "again": "New Transfer",
                 "back": "Back to Earn"
             }
         },

--- a/src/views/wallet/Transfer.vue
+++ b/src/views/wallet/Transfer.vue
@@ -121,7 +121,7 @@
                                 block
                                 :disabled="!canSendAgain"
                             >
-                                Start Again
+                                New Transaction
                             </v-btn>
                         </template>
                     </div>


### PR DESCRIPTION
change the button text when sending transaction from "start again" to "new transaction"
and the button in cross chain transfer from "start again" to "new transfer"