### PR TITLE
Add AliasPicker.vue, fetch and let user choose default address

### DIFF
--- a/src/components/SidePanels/MainPanel.vue
+++ b/src/components/SidePanels/MainPanel.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="main_panel">
-        <ConfirmLogout ref="logout"></ConfirmLogout>
+        <ConfirmLogout ref="logout" />
         <transition name="fade" mode="out-in">
             <transaction-history-panel class="panel_content"></transaction-history-panel>
         </transition>

--- a/src/components/wallet/manage/AliasPicker.vue
+++ b/src/components/wallet/manage/AliasPicker.vue
@@ -1,0 +1,182 @@
+<template>
+    <div>
+        <v-btn
+            v-if="multisigAliases.length > 0"
+            @click="openModal"
+            class="button_secondary"
+            small
+            depressed
+        >
+            Choose alias
+        </v-btn>
+        <Modal ref="modal" title="Alias picker">
+            <v-radio-group v-model="defaultAlias" @change="saveDefaultAddress">
+                <div class="assets">
+                    <span v-if="!account" class="label">
+                        <fa icon="exclamation-triangle"></fa>
+                        You need to save account in order to set Default value
+                    </span>
+                    <div class="row panel_nav">
+                        <div class="address_info_container">
+                            <h3 class="label">Personal</h3>
+                            <span class="label">{{ 'P-' + personalAddress.split('-')[1] }}</span>
+                        </div>
+                        <v-radio
+                            :disabled="!account"
+                            :value="personalAddress.split('-')[1]"
+                            class="default_radio_button"
+                        >
+                            <span slot="label" class="label">Default</span>
+                        </v-radio>
+                        <v-btn
+                            @click="chooseAlias(personalAddress.split('-')[1])"
+                            :disabled="selectedAlias === personalAddress.split('-')[1]"
+                            class="button_primary"
+                            small
+                            depressed
+                        >
+                            Activate
+                        </v-btn>
+                    </div>
+                    <div
+                        class="row panel_nav"
+                        v-for="(multisigAlias, index) in multisigAliases"
+                        :key="index"
+                    >
+                        <div class="address_info_container">
+                            <h3 class="label">Multisig alias {{ index + 1 }}</h3>
+                            <span class="label">{{ 'P-' + multisigAlias }}</span>
+                        </div>
+                        <v-radio
+                            :disabled="!account"
+                            :value="multisigAlias"
+                            class="default_radio_button"
+                        >
+                            <span slot="label" class="label">Default</span>
+                        </v-radio>
+                        <v-btn
+                            @click="chooseAlias(multisigAlias)"
+                            :disabled="selectedAlias === multisigAlias"
+                            class="button_primary"
+                            small
+                            depressed
+                        >
+                            Activate
+                        </v-btn>
+                    </div>
+                </div>
+            </v-radio-group>
+        </Modal>
+    </div>
+</template>
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import Modal from '@/components/modals/Modal.vue'
+import {
+    checkIfSavedLocally,
+    getAccountByIndex,
+    overwriteAccountAtIndex,
+} from '@/helpers/account_helper'
+import { iUserAccountEncrypted } from '@/store/types'
+
+@Component({
+    components: { Modal },
+})
+export default class AliasPicker extends Vue {
+    selectedAlias: string = ''
+    defaultAlias: string = ''
+    $refs!: {
+        modal: Modal
+    }
+
+    mounted() {
+        this.defaultAlias = this.account?.defaultAddress || this.personalAddress.split('-')[1]
+        this.chooseAlias(this.defaultAlias)
+    }
+
+    openModal() {
+        this.$refs.modal.open()
+    }
+
+    saveDefaultAddress() {
+        console.log('saveDefaultAddress', this.defaultAlias)
+        const account = this.account
+        if (!account) return
+        overwriteAccountAtIndex(
+            { ...account, defaultAddress: this.defaultAlias },
+            this.accountIndex
+        )
+    }
+
+    get account(): iUserAccountEncrypted | null {
+        return this.$store.getters['Accounts/account']
+    }
+
+    get accountIndex(): number {
+        return this.$store.getters['Accounts/accountIndex']
+    }
+
+    chooseAlias(alias: string) {
+        this.selectedAlias = alias
+        if (alias !== this.personalAddress.split('-')[1]) {
+            this.$store.state.activeWallet.selectedAlias = 'P-' + alias
+        } else {
+            this.$store.state.activeWallet.selectedAlias = undefined
+        }
+        this.$store.dispatch('Assets/updateUTXOs')
+        this.$store.dispatch('History/updateTransactionHistory')
+    }
+
+    get multisigAliases(): string[] {
+        return this.$store.getters['Accounts/multisigAliases']
+    }
+
+    get personalAddress(): string {
+        return this.$store.state.activeWallet.getCurrentAddressAvm()
+    }
+}
+</script>
+<style scoped lang="scss">
+@use '../../../styles/main';
+@import '../../../styles/main';
+
+.assets {
+    padding: 0 1.5rem;
+    gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    justify-self: center;
+    @include component-wrapper;
+    background-color: var(--bg-wallet-light);
+    font-size: 14px;
+
+    > * {
+        outline: none !important;
+        padding: 4px 8px;
+        border-radius: var(--border-radius-sm);
+    }
+}
+
+.label {
+    color: var(--primary-contrast-text);
+}
+
+.default_radio_button {
+    margin: 0 !important;
+}
+
+.address_info_container {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-right: auto;
+}
+</style>

--- a/src/components/wallet/sidebar/mountAccountMenu.ts
+++ b/src/components/wallet/sidebar/mountAccountMenu.ts
@@ -12,6 +12,7 @@ import vuetify from '@/plugins/vuetify'
 import AccountUserItem from './AccountUserItem.vue'
 import AccountKycItem from './AccountKycItem.vue'
 import AccountCard from './AccountCard.vue'
+import AliasPicker from '../manage/AliasPicker.vue'
 
 Vue.use(VueMeta)
 Vue.use(BootstrapVue)
@@ -19,6 +20,8 @@ Vue.component('datetime', Datetime)
 
 function selectAccountMenuItem(type: string) {
     switch (type) {
+        case 'alias':
+            return AliasPicker
         case 'kyc':
             return AccountKycItem
         case 'user':

--- a/src/explorer_api.ts
+++ b/src/explorer_api.ts
@@ -113,6 +113,11 @@ async function getAliasChains() {
     return res.data
 }
 
+async function getMultisigAliases(ownerAddress: string): Promise<string[]> {
+    let res = await explorer_api.get(`/v2/multisigalias/${ownerAddress}`)
+    return res.data.alias
+}
+
 export {
     explorer_api,
     getAddressHistory,
@@ -120,4 +125,5 @@ export {
     isAddressUsedX,
     getAddressChains,
     getAliasChains,
+    getMultisigAliases,
 }

--- a/src/js/HdHelper.ts
+++ b/src/js/HdHelper.ts
@@ -18,7 +18,7 @@ import { getAddressChains } from '@/explorer_api'
 import { AvaNetwork } from '@/js/AvaNetwork'
 import { ChainAlias } from './wallets/types'
 import { avmGetAllUTXOs, platformGetAllUTXOs } from '@/helpers/utxo_helper'
-import { updateFilterAddresses } from '../providers'
+import { updateFilterAddresses } from '@/providers'
 
 const INDEX_RANGE: number = 20 // a gap of at least 20 indexes is needed to claim an index unused
 

--- a/src/js/wallets/HdWalletCore.ts
+++ b/src/js/wallets/HdWalletCore.ts
@@ -196,7 +196,11 @@ abstract class HdWalletCore extends WalletCore {
     }
 
     getCurrentAddressPlatform(): string {
-        return this.platformHelper.getCurrentAddress()
+        if (this.selectedAlias) {
+            return this.selectedAlias
+        } else {
+            return this.platformHelper.getCurrentAddress()
+        }
     }
 
     getPlatformUTXOSet() {

--- a/src/js/wallets/SingletonWallet.ts
+++ b/src/js/wallets/SingletonWallet.ts
@@ -136,7 +136,11 @@ class SingletonWallet extends WalletCore implements AvaWalletCore, UnsafeWallet 
     }
 
     getCurrentAddressPlatform(): string {
-        return this.platformKeyPair.getAddressString()
+        if (this.selectedAlias) {
+            return this.selectedAlias
+        } else {
+            return this.platformKeyPair.getAddressString()
+        }
     }
 
     getBaseAddress(): string {

--- a/src/js/wallets/WalletCore.ts
+++ b/src/js/wallets/WalletCore.ts
@@ -36,6 +36,8 @@ abstract class WalletCore {
     isFetchUtxos: boolean
     isInit: boolean
 
+    selectedAlias?: string
+
     abstract getEvmAddressBech(): string
     abstract getEvmAddress(): string
     abstract getCurrentAddressAvm(): string

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -148,6 +148,7 @@ const store = new Vuex.Store({
             store.dispatch('Platform/update')
             store.dispatch('Assets/updateUTXOs')
             store.dispatch('Accounts/updateKycStatus')
+            store.dispatch('Accounts/updateMultisigAliases')
             store.dispatch('Launch/initialize')
         },
 

--- a/src/store/modules/accounts/accounts.ts
+++ b/src/store/modules/accounts/accounts.ts
@@ -20,6 +20,7 @@ import MnemonicWallet from '@/js/wallets/MnemonicWallet'
 import { SingletonWallet } from '@/js/wallets/SingletonWallet'
 import { makeKeyfile } from '@/js/Keystore'
 import { checkVerificationStatus } from '@/kyc_api'
+import { getMultisigAliases } from '@/explorer_api'
 
 const accounts_module: Module<AccountsState, RootState> = {
     namespaced: true,
@@ -27,6 +28,7 @@ const accounts_module: Module<AccountsState, RootState> = {
         accounts: [],
         accountIndex: null,
         kycStatus: false,
+        multisigAliases: [],
     },
     mutations: {
         loadAccounts(state) {
@@ -171,6 +173,13 @@ const accounts_module: Module<AccountsState, RootState> = {
             if (!wallet) return
             state.kycStatus = await checkVerificationStatus('0x' + wallet.ethAddress)
         },
+
+        async updateMultisigAliases({ state, rootState }) {
+            const wallet = rootState.activeWallet
+            if (!wallet) return
+            const addressP = wallet.getCurrentAddressPlatform()
+            state.multisigAliases = await getMultisigAliases(addressP)
+        },
     },
     getters: {
         hasAccounts(state: AccountsState, getters) {
@@ -199,8 +208,16 @@ const accounts_module: Module<AccountsState, RootState> = {
             return state.accounts[state.accountIndex]
         },
 
+        accountIndex(state: AccountsState): number | null {
+            return state.accountIndex
+        },
+
         kycStatus(state: AccountsState): boolean {
             return state.kycStatus
+        },
+
+        multisigAliases(state: AccountsState): string[] {
+            return state.multisigAliases
         },
     },
 }

--- a/src/store/modules/accounts/types.ts
+++ b/src/store/modules/accounts/types.ts
@@ -4,6 +4,7 @@ export interface AccountsState {
     accounts: iUserAccountEncrypted[]
     accountIndex: null | number
     kycStatus: boolean
+    multisigAliases: string[]
 }
 
 export interface ChangePasswordInput {

--- a/src/store/modules/assets/assets.ts
+++ b/src/store/modules/assets/assets.ts
@@ -547,6 +547,7 @@ const assets_module: Module<AssetsState, RootState> = {
                     addDictAmount(amt, assetID, dest)
                 }
             }
+            console.log('Platform balances updated', newBalance)
             state.platformBalances = newBalance
         },
     },

--- a/src/store/modules/network/network.ts
+++ b/src/store/modules/network/network.ts
@@ -162,6 +162,7 @@ const network_module: Module<NetworkState, RootState> = {
             dispatch('Platform/update', null, { root: true })
             dispatch('Platform/updateMinStakeAmount', null, { root: true })
             dispatch('updateTxFee')
+            dispatch('Accounts/updateMultisigAliases', null, { root: true })
             // Update tx history
             dispatch('History/updateTransactionHistory', null, { root: true })
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -132,6 +132,7 @@ export interface iUserAccountEncrypted {
     name: string
     baseAddresses: string[]
     wallet: AllKeyFileTypes
+    defaultAddress?: string
 }
 
 export interface iUserAccountDecrypted {


### PR DESCRIPTION
This PR adds AliasPicker component (which is exposed to camino-suite), that allows users (that have multisig aliases) activate particular address and set particular address to as default for when they log in (there is a requirement to save account to use this feature)
![image](https://user-images.githubusercontent.com/34208222/218136323-93c30b1e-91de-4b54-8667-6af900ce54e0.png)
![image](https://user-images.githubusercontent.com/34208222/218136366-d6639f9d-ca93-467b-b12b-f7b4ce641135.png)
![image](https://user-images.githubusercontent.com/34208222/218136508-b7593fb4-dde5-4bc5-83d1-dcb947405f1d.png)
