### PR TITLE
repair of the validator remaining time calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 node_modules
-camino-wallet-sdk
 /dist
 
 # Manually importing AVAJS

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules
+camino-wallet-sdk
 /dist
 
 # Manually importing AVAJS

--- a/src/components/wallet/earn/Validate/ValidatorInfo.vue
+++ b/src/components/wallet/earn/Validate/ValidatorInfo.vue
@@ -121,7 +121,7 @@ export default class ValidatorInfo extends Vue {
             this.upTime = parseFloat(this.nodeInfo.uptime) * 100
 
             var reaminingValidationDuration = moment.duration(
-                today.diff(moment(new Date(parseInt(this.nodeInfo.startTime) * 1000)))
+                moment(new Date(parseInt(this.nodeInfo.endTime) * 1000)).diff(today)
             )
 
             let dataReaminingValdiationDuration = {


### PR DESCRIPTION
Once the validator is running, you can see the remaining validation period. However, the calculation is wrong, it takes the time since the validator starts and not the remaining time until the validation end date. 
A solution to this has been provided