### PR TITLE
Dev deploy

### DIFF
--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -1,4 +1,4 @@
-name: 'Wallet Standalone Production'
+name: 'Wallet Standalone Dev Deployment'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -3,7 +3,7 @@ name: 'Wallet Standalone Dev Deployment'
 on:
   workflow_dispatch:
   push:
-    branches: [dev]
+    branches: [dev, dev-deploy]
     
 
 env:

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -4,15 +4,12 @@ on:
   workflow_dispatch:
   push:
     branches: [dev, dev-deploy]
-    
 
 env:
   repo_name: wallet-standalone-dev
   repo: https://github.com/chain4travel/camino-wallet.git
-  docker_image: "europe-west3-docker.pkg.dev/pwk-c4t-dev/internal-camino-dev/camino-wallet"
+  docker_image: 'europe-west3-docker.pkg.dev/pwk-c4t-dev/internal-camino-dev/camino-wallet'
   cloudrun_region: europe-west1
-
-  
 
 jobs:
   build_and_deploy:
@@ -35,7 +32,7 @@ jobs:
 
       - name: create docker image
         run: |
-          docker build . -t ${{ steps.setDefaults.outputs.docker_image }}:
+          docker build . -t ${{ steps.setDefaults.outputs.docker_image }}
 
       - name: Cloud authentication
         id: auth

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -1,0 +1,50 @@
+name: 'Wallet Standalone Production'
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [dev]
+    
+
+env:
+  repo_name: wallet-standalone-dev
+  repo: https://github.com/chain4travel/camino-wallet.git
+  docker_image: "europe-west3-docker.pkg.dev/pwk-c4t-dev/internal-camino-dev/camino-wallet"
+  cloudrun_region: europe-west1
+
+  
+
+jobs:
+  build_and_deploy:
+    name: Build Docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: '18'
+
+      - name: Set defaults
+        id: setDefaults
+        run: |
+          export DATE=$(date '+%d_%m_%y')
+          export BUILD_NUM=${{github.run_number}}
+          export TAG="${GITHUB_REF##*/}_${DATE}_${BUILD_NUM}"
+          echo "docker_image=${{ env.docker_image }}:$TAG" >> $GITHUB_OUTPUT
+
+      - name: create docker image
+        run: |
+          docker build . -t ${{ steps.setDefaults.outputs.docker_image }}:
+
+      - name: Cloud authentication
+        id: auth
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+
+      - name: push and deploy docker
+        run: |
+          gcloud auth configure-docker --quiet europe-west3-docker.pkg.dev
+          docker push ${{ steps.setDefaults.outputs.docker_image }}
+          gcloud run deploy ${{ env.repo_name }} --image ${{ steps.setDefaults.outputs.docker_image }} --region=${{ env.cloudrun_region }}

--- a/.github/workflows/dev_deployment.yml
+++ b/.github/workflows/dev_deployment.yml
@@ -3,7 +3,7 @@ name: 'Wallet Standalone Dev Deployment'
 on:
   workflow_dispatch:
   push:
-    branches: [dev, dev-deploy]
+    branches: [dev]
 
 env:
   repo_name: wallet-standalone-dev


### PR DESCRIPTION
added a workflow to deploy to dev.wallet.camino.network
This workflow needs to be added to c4t branch so that workflow_dispatch option works.

This workflow is 10 minutes faster than cloudrun build due to the usage of yarn caches.

this workflow runs whenever there is a push on dev branch or someone trigger it to deploy other branch.