### PR TITLE
fix icons color in importKeys component

### DIFF
--- a/src/components/modals/ImportKeys.vue
+++ b/src/components/modals/ImportKeys.vue
@@ -94,6 +94,10 @@ export default class ImportKeys extends Vue {
 <style scoped lang="scss">
 @use '../../styles/abstracts/mixins';
 
+.v-tabs > .v-tabs-bar .v-tab:not(.v-tab--active) > .v-icon {
+    color: var(--primary-color);
+    opacity: 0.6;
+}
 .add_key_body {
     padding: 30px;
     max-width: 450px;


### PR DESCRIPTION
this pr is to fix the color of icons in the importKeys component
before :
<img width="568" alt="Screenshot 2023-04-04 at 12 47 45" src="https://user-images.githubusercontent.com/51858084/229796451-b50688ee-f093-4d55-be42-78c3633987ea.png">
after :
<img width="553" alt="Screenshot 2023-04-04 at 12 47 16" src="https://user-images.githubusercontent.com/51858084/229796515-8ea011a0-2491-4aa3-8e2d-988a439ccff7.png">
