### PR TITLE
add updating the state of showing wallet switcher component

### DIFF
--- a/src/bootloader.ts
+++ b/src/bootloader.ts
@@ -14,12 +14,20 @@ Vue.use(BootstrapVue)
 Vue.component('datetime', Datetime)
 
 export const mount = (el: string, appSuiteStore: any) => {
-    const { setUpdateStore, setLogOut, setAccount, dispatchNotification, navigate } = appSuiteStore
+    const {
+        setUpdateStore,
+        setLogOut,
+        setAccount,
+        dispatchNotification,
+        navigate,
+        updateShowAlias,
+    } = appSuiteStore
     const MyPlugin = {
         install(Vue) {
             Vue.prototype.globalHelper = () => {
                 return {
                     updateSuiteStore: (s) => setUpdateStore(s),
+                    updateShowAlias: () => updateShowAlias(),
                     logout: () => setLogOut(true),
                     setAccount: (acc) => setAccount(acc),
                     dispatchNotification: (params) => dispatchNotification(params),

--- a/src/components/modals/ImportKeys.vue
+++ b/src/components/modals/ImportKeys.vue
@@ -43,6 +43,7 @@ import AddKeyFile from '@/components/wallet/manage/AddKeyFile.vue'
 import AddKeyString from '@/components/wallet/manage/AddKeyString.vue'
 import AddMnemonic from '@/components/wallet/manage/AddMnemonic.vue'
 import AddMultisigAlias from '@/components/wallet/manage/AddMultisigAlias.vue'
+import { getMultisigAliases } from '@/explorer_api'
 
 @Component({
     components: {
@@ -85,7 +86,9 @@ export default class ImportKeys extends Vue {
             message: this.$t('keys.import_key_success_msg'),
             type: 'success',
         }
-        let { dispatchNotification } = this.globalHelper()
+        let { dispatchNotification, updateShowAlias } = this.globalHelper()
+        this.$store.dispatch('fetchMultiSigAliases', { disable: false })
+        updateShowAlias()
         dispatchNotification(payload)
     }
 }

--- a/src/components/wallet/manage/MyKeys.vue
+++ b/src/components/wallet/manage/MyKeys.vue
@@ -51,7 +51,7 @@
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Vue, Component } from 'vue-property-decorator'
+import { Vue, Component, Watch } from 'vue-property-decorator'
 
 import KeyRow from '@/components/wallet/manage/KeyRow.vue'
 import RememberKey from '@/components/misc/RememberKey.vue'
@@ -161,7 +161,11 @@ export default class MyKeys extends Vue {
     get activeWallet(): WalletType {
         return this.$store.state.activeWallet
     }
-
+    @Watch('wallets.length')
+    async onWalletsChange() {
+        if (this.wallets.length > 1)
+            await this.$store.dispatch('fetchMultiSigAliases', { disable: false })
+    }
     get multiSigAliases(): string[] {
         return this.$store.getters.multiSigAliases
     }


### PR DESCRIPTION
this pr is to complete the changes done in the suite app to update the state to show the wallet switcher component
what has been done in this pr :
- import an action from the suite before the wallet component is mounted
- add the action to the globalHelpers
- fire the action after a new key is imported in order to check in the suite if this key has multiple aliases pending