### PR TITLE
Sending funds on the P-Chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
         "weekstart": "1.0.1"
     },
     "dependencies": {
-        "@c4tplatform/signavaultjs": "^1.0.5",
+        "@c4tplatform/signavaultjs": "^1.0.11",
         "@cypress/xpath": "^2.0.3",
         "vue": "^2.6.11",
         "vue-cli-plugin-vuetify": "^2.0.3",

--- a/src/components/misc/BalancePopup/BalanceDropdown.vue
+++ b/src/components/misc/BalancePopup/BalanceDropdown.vue
@@ -33,7 +33,6 @@ export default class BalanceDropdown extends Vue {
     @Model('change', { type: AvaAsset }) readonly asset!: AvaAsset
 
     get assetArray(): AvaAsset[] {
-        // return this.$store.getters.walletAssetsArray
         return this.$store.getters['Assets/walletAssetsArray']
     }
 
@@ -52,28 +51,13 @@ export default class BalanceDropdown extends Vue {
         return sym
     }
 
-    // get isPopup(){
-    //     if(this.balancePopup){
-    //         return this.balancePopup.isActive;
-    //     }
-    //     return false;
-    // }
-
     showPopup() {
         this.$refs.token_modal.open()
-        // this.balancePopup.isActive = true
-        // this.isPopup = true
     }
 
-    onclose() {
-        // this.isPopup = false
-    }
+    onclose() {}
 
     onselect(asset: AvaAsset) {
-        // this.selected = asset;
-        // this.balancePopup.isActive = false
-        // this.isPopup = false
-
         this.$emit('change', asset)
     }
 }

--- a/src/components/misc/CurrencyInputDropdown.vue
+++ b/src/components/misc/CurrencyInputDropdown.vue
@@ -46,6 +46,7 @@ import BalanceDropdown from '@/components/misc/BalancePopup/BalanceDropdown.vue'
 import { ava } from '@/AVA'
 import Big from 'big.js'
 import { bnToBig } from '@/helpers/helper'
+import { ChainIdType } from '@/constants'
 
 @Component({
     components: {
@@ -60,6 +61,7 @@ export default class CurrencyInputDropdown extends Vue {
     @Prop({ default: () => [] }) disabled_assets!: AvaAsset[]
     @Prop({ default: '' }) initial!: string
     @Prop({ default: false }) disabled!: boolean
+    @Prop() chainId!: ChainIdType
 
     $refs!: {
         bigIn: BigNumInput
@@ -148,12 +150,10 @@ export default class CurrencyInputDropdown extends Vue {
     }
 
     get walletAssetsArray(): AvaAsset[] {
-        // return this.$store.getters.walletAssetsArray
         return this.$store.getters['Assets/walletAssetsArray']
     }
 
     get walletAssetsDict(): IWalletAssetsDict {
-        // return this.$store.getters['walletAssetsDict']
         return this.$store.getters['Assets/walletAssetsDict']
     }
 
@@ -167,6 +167,7 @@ export default class CurrencyInputDropdown extends Vue {
 
         let assetId = this.asset_now.id
         let balance = this.walletAssetsDict[assetId]
+        const amount = this.chainId === 'P' ? balance.amountExtra : balance.amount
 
         let avaxId = this.avaxAsset.id
 
@@ -174,15 +175,15 @@ export default class CurrencyInputDropdown extends Vue {
         if (assetId === avaxId) {
             let fee = ava.XChain().getTxFee()
             // console.log(fee);
-            if (fee.gte(balance.amount)) {
+            if (fee.gte(amount)) {
                 return new BN(0)
             } else {
-                return balance.amount.sub(fee)
+                return amount.sub(fee)
             }
         }
 
-        if (balance.amount.isZero()) return null
-        return balance.amount
+        if (amount.isZero()) return null
+        return amount
     }
 
     get maxAmountBig(): Big {

--- a/src/components/wallet/earn/ChainTransfer/Form.vue
+++ b/src/components/wallet/earn/ChainTransfer/Form.vue
@@ -53,8 +53,9 @@ import { BN } from '@c4tplatform/caminojs/dist'
 import Big from 'big.js'
 import { bnToBig } from '@/helpers/helper'
 import { ChainIdType } from '@/constants'
-import MnemonicWallet from '@/js/wallets/MnemonicWallet'
 import { ChainSwapFormData } from '@/components/wallet/earn/ChainTransfer/types'
+import { MultisigWallet } from '@/js/wallets/MultisigWallet'
+import { AvaWalletCore } from '@/js/wallets/types'
 
 const chainTypes: ChainIdType[] = ['X', 'P', 'C']
 const chainNames = {
@@ -91,6 +92,9 @@ export default class Form extends Vue {
     }
 
     get sourceOptions(): ChainIdType[] {
+        if (this.isMultisigWallet) {
+            return ['P']
+        }
         if (!this.isEVMSupported) {
             return ['X', 'P']
         }
@@ -100,6 +104,9 @@ export default class Form extends Vue {
     }
 
     get destinationOptions(): ChainIdType[] {
+        if (this.isMultisigWallet) {
+            return ['C']
+        }
         return {
             X: ['P', 'C'],
             P: ['X', 'C'],
@@ -113,9 +120,12 @@ export default class Form extends Vue {
         this.onChange()
     }
 
-    get wallet() {
-        let wallet: MnemonicWallet = this.$store.state.activeWallet
-        return wallet
+    get wallet(): AvaWalletCore {
+        return this.$store.state.activeWallet
+    }
+
+    get isMultisigWallet() {
+        return this.wallet instanceof MultisigWallet
     }
 
     get isEVMSupported() {
@@ -143,6 +153,10 @@ export default class Form extends Vue {
     }
 
     onChange() {
+        if (!this.sourceOptions.includes(this.sourceChain)) this.sourceChain = this.sourceOptions[0]
+        if (!this.destinationOptions.includes(this.targetChain))
+            this.targetChain = this.destinationOptions[0]
+
         let data: ChainSwapFormData = {
             sourceChain: this.sourceChain,
             destinationChain: this.targetChain,

--- a/src/components/wallet/transfer/ChainInput.vue
+++ b/src/components/wallet/transfer/ChainInput.vue
@@ -2,6 +2,7 @@
     <div v-if="isEVMSupported" class="header">
         <h1>{{ $t('transfer.source_chain.title') }}</h1>
         <div class="chain_select">
+            <button :active="formType === 'P'" @click="set('P')">P</button>
             <button :active="formType === 'X'" @click="set('X')">X</button>
             <button :active="formType === 'C'" @click="set('C')">C</button>
         </div>
@@ -10,11 +11,10 @@
 <script lang="ts">
 import { Vue, Component, Model, Prop } from 'vue-property-decorator'
 import { ChainIdType } from '@/constants'
-import { CurrencyType } from '@/components/misc/CurrencySelect/types'
 
 @Component
 export default class ChainInput extends Vue {
-    @Model('change', { type: String }) readonly formType!: CurrencyType
+    @Model('change', { type: String }) readonly formType!: ChainIdType
     @Prop({ default: false }) disabled!: boolean
 
     set(val: ChainIdType) {
@@ -46,14 +46,11 @@ label {
     display: flex;
     width: max-content;
     > button {
-        //border: 1px solid var(--primary-color);
-        //margin-right: 14px;
         padding-right: 14px;
         opacity: 0.2;
         transition-duration: 0.1s;
         cursor: pointer;
         color: var(--primary-color);
-        //background-color: var(--bg-light);
         display: flex;
         align-items: center;
         font-size: 28px;
@@ -62,9 +59,7 @@ label {
             opacity: 1;
         }
         &[active] {
-            //background-color: var(--secondary-color);
             color: var(--secondary-color);
-            //border-color: var(--primary-color-light);
             opacity: 1;
         }
     }
@@ -74,7 +69,7 @@ label {
     .chain_select {
         width: 100%;
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 1fr 1fr 1fr;
         column-gap: 14px;
         > button {
             margin: 0;

--- a/src/components/wallet/transfer/ChainInput.vue
+++ b/src/components/wallet/transfer/ChainInput.vue
@@ -1,6 +1,13 @@
 <template>
     <div v-if="isEVMSupported" class="header">
-        <h1>{{ $t('transfer.source_chain.title') }}</h1>
+        <div class="test">
+            <h1>{{ $t('transfer.source_chain.title') }}</h1>
+            <div v-if="formType === 'P'" class="refresh">
+                <button @click="refresh">
+                    <v-icon>mdi-refresh</v-icon>
+                </button>
+            </div>
+        </div>
         <div class="chain_select">
             <button :active="formType === 'P'" @click="set('P')">P</button>
             <button :active="formType === 'X'" @click="set('X')">X</button>
@@ -22,6 +29,9 @@ export default class ChainInput extends Vue {
         this.$emit('change', val)
     }
 
+    refresh() {
+        this.$emit('refresh')
+    }
     get wallet() {
         return this.$store.state.activeWallet
     }
@@ -40,6 +50,15 @@ label {
 .header {
     h1 {
         font-weight: normal;
+    }
+}
+.test {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    i {
+        color: white;
+        margin-right: 1rem;
     }
 }
 .chain_select {

--- a/src/components/wallet/transfer/ChainInput.vue
+++ b/src/components/wallet/transfer/ChainInput.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="isEVMSupported" class="header">
-        <div class="test">
+        <div class="header__container">
             <h1>{{ $t('transfer.source_chain.title') }}</h1>
             <div v-if="formType === 'P'" class="refresh">
                 <button @click="refresh">
@@ -51,16 +51,17 @@ label {
     h1 {
         font-weight: normal;
     }
-}
-.test {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    i {
-        color: white;
-        margin-right: 1rem;
+    &__container {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        i {
+            color: white;
+            margin-right: 1rem;
+        }
     }
 }
+
 .chain_select {
     display: flex;
     width: max-content;

--- a/src/components/wallet/transfer/TxList.vue
+++ b/src/components/wallet/transfer/TxList.vue
@@ -50,7 +50,6 @@ export default class TxList extends Vue {
     tx_list: ITransaction[] = []
     disabledAssets: AvaAsset[][] = []
     next_initial: AvaAsset | null = null
-    dummy = new BN(100)
 
     @Prop({ default: false }) disabled!: boolean
     @Prop() chainId!: ChainIdType

--- a/src/components/wallet/transfer/TxList.vue
+++ b/src/components/wallet/transfer/TxList.vue
@@ -11,6 +11,7 @@
                 :disabled_assets="disabledAssets[i]"
                 :initial="tx.asset.id"
                 :disabled="disabled"
+                :chainId="chainId"
             ></currency-input-dropdown>
             <button
                 @click="removeTx(i)"
@@ -38,6 +39,7 @@ import CurrencyInputDropdown from '@/components/misc/CurrencyInputDropdown.vue'
 import AvaAsset from '@/js/AvaAsset'
 import { AssetsDict } from '@/store/modules/assets/types'
 import { ICurrencyInputDropdownValue, ITransaction } from '@/components/wallet/transfer/types'
+import { ChainIdType } from '@/constants'
 
 @Component({
     components: {
@@ -48,8 +50,10 @@ export default class TxList extends Vue {
     tx_list: ITransaction[] = []
     disabledAssets: AvaAsset[][] = []
     next_initial: AvaAsset | null = null
+    dummy = new BN(100)
 
     @Prop({ default: false }) disabled!: boolean
+    @Prop() chainId!: ChainIdType
 
     deactivated() {
         this.reset()
@@ -159,15 +163,16 @@ export default class TxList extends Vue {
     }
 
     get assets_list(): AvaAsset[] {
-        // return this.$store.getters.walletAssetsArray
         return this.$store.getters['Assets/walletAssetsArray']
     }
+
     get assets(): AssetsDict {
-        // return this.$store.getters.walletAssetsDict
         return this.$store.getters['Assets/walletAssetsDict']
     }
+
     get showAdd(): boolean {
         if (this.disabled) return false
+        if (this.chainId === 'P') return false
         if (this.tx_list.length === this.assets_list.length || this.assets_list.length === 0) {
             return false
         }

--- a/src/helpers/wallet_helper.ts
+++ b/src/helpers/wallet_helper.ts
@@ -1,4 +1,4 @@
-import { ava } from '@/AVA'
+import { ava, bintools } from '@/AVA'
 import {
     UTXO as PlatformUTXO,
     UTXOSet as PlatformUTXOSet,
@@ -516,6 +516,32 @@ class WalletHelper {
         let unsignedTx = new UnsignedTx()
         unsignedTx.fromBuffer(Buffer.from(utx, 'hex'))
         return unsignedTx.getTransaction().getTypeName()
+    }
+
+    static getToAddressFromUtx(utx: UnsignedTx, msigAlias?: string) {
+        const tx = utx.getTransaction()
+
+        const el = tx?.getOuts()?.find((o) => {
+            const _address =
+                'P' +
+                bintools.addressToString(
+                    ava.getHRP(),
+                    tx?.getBlockchainID().toString(),
+                    o?.getAddresses()?.[0]
+                )
+            return _address !== msigAlias
+        })
+
+        if (el) {
+            const toAddress =
+                'P' +
+                bintools.addressToString(
+                    ava.getHRP(),
+                    tx?.getBlockchainID().toString(),
+                    el?.getAddresses()?.[0]
+                )
+            return toAddress
+        }
     }
 }
 

--- a/src/helpers/wallet_helper.ts
+++ b/src/helpers/wallet_helper.ts
@@ -26,6 +26,7 @@ import { GetValidatorsResponse } from '@/store/modules/platform/types'
 import { MultisigWallet } from '@/js/wallets/MultisigWallet'
 import { ValidatorRaw } from '@/components/misc/ValidatorList/types'
 import { SignatureError } from '@c4tplatform/caminojs/dist/common'
+import { ChainIdType } from '@/constants'
 
 class WalletHelper {
     static async getStake(wallet: WalletType): Promise<BN> {

--- a/src/js/AvaAsset.ts
+++ b/src/js/AvaAsset.ts
@@ -11,6 +11,7 @@ class AvaAsset {
     amountLocked: BN
     // Native asset P chain, Wallet Staking
     amountExtra: BN
+    amountExtraLocked: BN
     private readonly pow: Big
     constructor(id: string, name: string, symbol: string, denomination: number) {
         this.id = id
@@ -20,6 +21,7 @@ class AvaAsset {
         this.amount = new BN(0, 10)
         this.amountLocked = new BN(0, 10)
         this.amountExtra = new BN(0, 10)
+        this.amountExtraLocked = new BN(0, 10)
         this.pow = Big(10).pow(denomination)
     }
 
@@ -35,10 +37,15 @@ class AvaAsset {
         this.amountExtra = this.amountExtra.add(val)
     }
 
+    addExtraLocked(val: BN): void {
+        this.amountExtraLocked = this.amountExtraLocked.add(val)
+    }
+
     resetBalance() {
         this.amount = new BN(0, 10)
         this.amountLocked = new BN(0, 10)
         this.amountExtra = new BN(0, 10)
+        this.amountExtraLocked = new BN(0, 10)
     }
 
     getAmount(locked: boolean = false): Big {
@@ -58,7 +65,7 @@ class AvaAsset {
     }
 
     getTotalAmount(): BN {
-        return this.amount.add(this.amountLocked).add(this.amountExtra)
+        return this.amount.add(this.amountLocked).add(this.amountExtra).add(this.amountExtraLocked)
     }
 
     toStringTotal(): string {
@@ -69,12 +76,6 @@ class AvaAsset {
     toString() {
         let big: Big = Big(this.amount.toString(10)).div(this.pow)
         return big.toLocaleString(this.denomination)
-        // if(big.lt(Big('0.001'))){
-        //     return big.toLocaleString(this.denomination);
-        // }else{
-        //     let min = Math.min(this.denomination, 2);
-        //     return big.toLocaleString(min);
-        // }
     }
 }
 

--- a/src/js/wallets/LedgerWallet.ts
+++ b/src/js/wallets/LedgerWallet.ts
@@ -932,11 +932,12 @@ class LedgerWallet extends HdWalletCore implements AvaWalletCore {
     }
 
     async issueBatchTx(
+        chainId: ChainIdType,
         orders: (ITransaction | AVMUTXO)[],
         addr: string,
         memo: Buffer | undefined
     ): Promise<string> {
-        return await WalletHelper.issueBatchTx(this, orders, addr, memo)
+        return await WalletHelper.issueBatchTx(this, chainId, orders, addr, memo)
     }
 
     async delegate(

--- a/src/js/wallets/MnemonicWallet.ts
+++ b/src/js/wallets/MnemonicWallet.ts
@@ -37,6 +37,7 @@ import Erc20Token from '@/js/Erc20Token'
 import { WalletHelper } from '@/helpers/wallet_helper'
 import { Transaction } from '@ethereumjs/tx'
 import MnemonicPhrase from '@/js/wallets/MnemonicPhrase'
+import { ChainIdType } from '@/constants'
 
 // HD WALLET
 // Accounts are not used and the account index is fixed to 0
@@ -212,11 +213,12 @@ export default class MnemonicWallet extends HdWalletCore implements IAvaHdWallet
     }
 
     async issueBatchTx(
+        chainId: ChainIdType,
         orders: (ITransaction | AVMUTXO)[],
         addr: string,
         memo: BufferAvalanche | undefined
     ): Promise<string> {
-        return await WalletHelper.issueBatchTx(this, orders, addr, memo)
+        return await WalletHelper.issueBatchTx(this, chainId, orders, addr, memo)
     }
 
     // returns a keychain that has all the derived private/public keys for X chain

--- a/src/js/wallets/MultisigWallet.ts
+++ b/src/js/wallets/MultisigWallet.ts
@@ -457,6 +457,25 @@ class MultisigWallet extends WalletCore implements AvaWalletCore {
         })
     }
 
+    async cancelExternal(tx: ModelMultisigTx) {
+        const sv = SignaVault()
+        const timestamp = Math.floor(Date.now() / 1000).toString()
+        const signingKeyPair = this.wallets?.[0]?.getStaticKeyPair()
+
+        if (!signingKeyPair) {
+            console.log('wallet returned undefined staticKeyPair')
+            return
+        }
+        const signatureAliasTimestamp = signingKeyPair
+            .sign(Buffer.from(createHash('sha256').update(Buffer.from(timestamp)).digest()))
+            ?.toString('hex')
+        return sv.cancelMultisigTx(tx.id, {
+            timestamp: timestamp,
+            signature: signatureAliasTimestamp,
+            id: tx?.id,
+        })
+    }
+
     /******************** INTERNAL *******************************/
 
     _aliasAddress(chainID: string) {

--- a/src/js/wallets/MultisigWallet.ts
+++ b/src/js/wallets/MultisigWallet.ts
@@ -43,6 +43,7 @@ import { Transaction } from '@ethereumjs/tx'
 import { ITransaction } from '@/components/wallet/transfer/types'
 import { buildUnsignedTransaction } from '../TxHelper'
 import createHash from 'create-hash'
+import { WalletHelper } from '@/helpers/wallet_helper'
 
 const NotImplementedError = new Error('Not implemented in MultisigWwallet')
 

--- a/src/js/wallets/MultisigWallet.ts
+++ b/src/js/wallets/MultisigWallet.ts
@@ -262,11 +262,12 @@ class MultisigWallet extends WalletCore implements AvaWalletCore {
     }
 
     async issueBatchTx(
+        chainId: ChainIdType,
         orders: (AVMUTXO | ITransaction)[],
         addr: string,
         memo?: Buffer
     ): Promise<string> {
-        throw NotImplementedError
+        return await WalletHelper.issueBatchTx(this, chainId, orders, addr, memo)
     }
 
     async buildUnsignedTransaction(

--- a/src/js/wallets/SingletonWallet.ts
+++ b/src/js/wallets/SingletonWallet.ts
@@ -37,6 +37,7 @@ import { WalletCore } from '@/js/wallets/WalletCore'
 import { WalletHelper } from '@/helpers/wallet_helper'
 import { avmGetAllUTXOs, platformGetAllUTXOs } from '@/helpers/utxo_helper'
 import { Transaction } from '@ethereumjs/tx'
+import { ChainIdType } from '@/constants'
 
 class SingletonWallet extends WalletCore implements AvaWalletCore, UnsafeWallet {
     keyChain: AVMKeyChain
@@ -221,11 +222,12 @@ class SingletonWallet extends WalletCore implements AvaWalletCore, UnsafeWallet 
     }
 
     async issueBatchTx(
+        chainId: ChainIdType,
         orders: (ITransaction | AVMUTXO)[],
         addr: string,
         memo: BufferAvalanche | undefined
     ): Promise<string> {
-        return await WalletHelper.issueBatchTx(this, orders, addr, memo)
+        return await WalletHelper.issueBatchTx(this, chainId, orders, addr, memo)
     }
 
     getFirstAvailableAddressPlatform(): string {

--- a/src/js/wallets/types.ts
+++ b/src/js/wallets/types.ts
@@ -32,6 +32,7 @@ import { SingletonWallet } from '@/js/wallets/SingletonWallet'
 import { MultisigWallet } from '@/js/wallets/MultisigWallet'
 import { ExportChainsC, ExportChainsP, ExportChainsX } from '@c4tplatform/camino-wallet-sdk/dist'
 import { UTXOSet as EVMUTXOSet } from '@c4tplatform/caminojs/dist/apis/evm/utxos'
+import { ChainIdType } from '@/constants'
 
 export interface IIndexKeyCache {
     [index: number]: AVMKeyPair
@@ -125,7 +126,12 @@ export interface AvaWalletCore extends IAddressManager {
     importToPlatformChain(sourceChain: ExportChainsP): Promise<string>
     importToXChain(sourceChain: ExportChainsX): Promise<string>
     importToCChain(sourceChain: ExportChainsC, baseFee: BN, utxoSet?: EVMUTXOSet): Promise<string>
-    issueBatchTx(orders: (AVMUTXO | ITransaction)[], addr: string, memo?: Buffer): Promise<string>
+    issueBatchTx(
+        chainId: ChainIdType,
+        orders: (AVMUTXO | ITransaction)[],
+        addr: string,
+        memo?: Buffer
+    ): Promise<string>
     signMessage(msg: string, address: string): Promise<string>
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -493,7 +493,7 @@
             "requirements_introduction": "In order to set up your validator node you have to:",
             "nodeId": "Node ID",
             "label_1": "Validator Node's Private Key",
-            "description_1": "Please enter the Node's Static Private Key (you can receive one by calling admin.getNodeSigner on your node)",
+            "description_1": "Node Private Key",
             "label_3": "P-Chain address your validator node will be assigned to",
             "label_4": "Are you sure you want to initiate a transaction? This requires signatures from other wallets in the multisignature wallet and cannot be undone",
             "label_5": "Tx Details",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -167,6 +167,11 @@
             "amount": "Amount",
             "token": "Token"
         },
+        "multisig": {
+            "execute_transaction": "Execute transaction",
+            "sign_transaction": "Sign transaction",
+            "abort_transaction": "Abort transaction"
+        },
         "source_chain": {
             "title": "Source Chain"
         },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -377,11 +377,12 @@ export default new Vuex.Store({
             let wallet = state.activeWallet
             if (!wallet) return 'error'
 
-            let toAddr = data.toAddress
-            let orders = data.orders
-            let memo = data.memo
-
-            let txId: string = await wallet.issueBatchTx(orders, toAddr, memo)
+            let txId: string = await wallet.issueBatchTx(
+                data.chainId,
+                data.orders,
+                data.toAddress,
+                data.memo
+            )
             return txId
         },
 

--- a/src/store/modules/assets/assets.ts
+++ b/src/store/modules/assets/assets.ts
@@ -622,14 +622,14 @@ const assets_module: Module<AssetsState, RootState> = {
                 // @ts-ignore
                 if (asset.id === state.AVA_ASSET_ID) {
                     if (depositAndBond) {
-                        asset.addExtra(getters.walletPlatformBalanceUnlocked)
-                        asset.addExtraLocked(getters.walletPlatformBalanceLocked)
-                        asset.addExtraLocked(getters.walletPlatformBalanceLockedStakeable)
-                    } else {
                         asset.addExtra(getters.walletPlatformBalance)
-                        asset.addExtraLocked(getters.walletPlatformBalanceLocked)
-                        asset.addExtraLocked(getters.walletPlatformBalanceLockedStakeable)
-                        asset.addExtraLocked(getters.walletStakingBalance)
+                        asset.addExtra(getters.walletPlatformBalanceLocked)
+                        asset.addExtra(getters.walletPlatformBalanceLockedStakeable)
+                    } else {
+                        asset.addExtra(getters.walletStakingBalance)
+                        asset.addExtra(getters.walletPlatformBalance)
+                        asset.addExtra(getters.walletPlatformBalanceLocked)
+                        asset.addExtra(getters.walletPlatformBalanceLockedStakeable)
                     }
                 }
 

--- a/src/store/modules/assets/assets.ts
+++ b/src/store/modules/assets/assets.ts
@@ -56,7 +56,7 @@ const assets_module: Module<AssetsState, RootState> = {
         ERCNft: ERCNftModule,
     },
     state: {
-        AVA_ASSET_ID: null,
+        AVA_ASSET_ID: '',
         // isUpdateBalance: false,
         assets: [],
         assetsDict: {}, // holds meta data of assets
@@ -120,7 +120,7 @@ const assets_module: Module<AssetsState, RootState> = {
             state.nftUTXOs = []
             state.nftMintUTXOs = []
             state.balanceDict = {}
-            state.AVA_ASSET_ID = null
+            state.AVA_ASSET_ID = ''
         },
         saveCustomErc20Tokens(state) {
             let tokens: Erc20Token[] = state.erc20TokensCustom
@@ -622,14 +622,14 @@ const assets_module: Module<AssetsState, RootState> = {
                 // @ts-ignore
                 if (asset.id === state.AVA_ASSET_ID) {
                     if (depositAndBond) {
-                        asset.addExtra(getters.walletPlatformBalance)
-                        asset.addExtra(getters.walletPlatformBalanceLocked)
-                        asset.addExtra(getters.walletPlatformBalanceLockedStakeable)
+                        asset.addExtra(getters.walletPlatformBalanceUnlocked)
+                        asset.addExtraLocked(getters.walletPlatformBalanceLocked)
+                        asset.addExtraLocked(getters.walletPlatformBalanceLockedStakeable)
                     } else {
-                        asset.addExtra(getters.walletStakingBalance)
                         asset.addExtra(getters.walletPlatformBalance)
-                        asset.addExtra(getters.walletPlatformBalanceLocked)
-                        asset.addExtra(getters.walletPlatformBalanceLockedStakeable)
+                        asset.addExtraLocked(getters.walletPlatformBalanceLocked)
+                        asset.addExtraLocked(getters.walletPlatformBalanceLockedStakeable)
+                        asset.addExtraLocked(getters.walletStakingBalance)
                     }
                 }
 
@@ -639,7 +639,6 @@ const assets_module: Module<AssetsState, RootState> = {
         },
 
         walletAssetsArray(state, getters): AvaAsset[] {
-            // let assetsDict: IWalletAssetsDict = getters.walletAssetsDict
             let assetsDict: IWalletAssetsDict = getters.walletAssetsDict
             let res: AvaAsset[] = []
 
@@ -660,35 +659,31 @@ const assets_module: Module<AssetsState, RootState> = {
             return state.nftFams
         },
 
-        walletStakingBalance(state, getters, rootState, rootGetters): BN {
+        walletStakingBalance(state, getters, rootState): BN {
             let wallet = rootState.activeWallet
             if (!wallet) return new BN(0)
 
             return wallet.stakeAmount
         },
 
-        walletPlatformBalance(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
-            return state.platformBalances.balances[avaxAssetID] ?? ZeroBN
+        walletPlatformBalance(state): BN {
+            return state.platformBalances.balances[state.AVA_ASSET_ID] ?? ZeroBN
         },
 
-        walletPlatformBalanceUnlocked(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
-            return state.platformBalances.unlocked[avaxAssetID] ?? ZeroBN
+        walletPlatformBalanceUnlocked(state): BN {
+            return state.platformBalances.unlocked[state.AVA_ASSET_ID] ?? ZeroBN
         },
 
-        walletPlatformBalanceLocked(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
-            return state.platformBalances.locked[avaxAssetID] ?? ZeroBN
+        walletPlatformBalanceLocked(state): BN {
+            return state.platformBalances.locked[state.AVA_ASSET_ID] ?? ZeroBN
         },
 
-        walletPlatformBalanceLockedStakeable(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
-            return state.platformBalances.lockedStakeable[avaxAssetID] ?? ZeroBN
+        walletPlatformBalanceLockedStakeable(state): BN {
+            return state.platformBalances.lockedStakeable[state.AVA_ASSET_ID] ?? ZeroBN
         },
 
-        walletPlatformBalanceTotalLocked(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
+        walletPlatformBalanceTotalLocked(state): BN {
+            const avaxAssetID = state.AVA_ASSET_ID
             return (state.platformBalances.deposited[avaxAssetID] ?? ZeroBN)
                 .add(state.platformBalances.bonded[avaxAssetID] ?? ZeroBN)
                 .add(state.platformBalances.bondedDeposited[avaxAssetID] ?? ZeroBN)
@@ -696,19 +691,16 @@ const assets_module: Module<AssetsState, RootState> = {
                 .add(state.platformBalances.lockedStakeable[avaxAssetID] ?? ZeroBN)
         },
 
-        walletPlatformBalanceDeposited(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
-            return state.platformBalances.deposited[avaxAssetID] ?? ZeroBN
+        walletPlatformBalanceDeposited(state): BN {
+            return state.platformBalances.deposited[state.AVA_ASSET_ID] ?? ZeroBN
         },
 
-        walletPlatformBalanceBonded(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
-            return state.platformBalances.bonded[avaxAssetID] ?? ZeroBN
+        walletPlatformBalanceBonded(state): BN {
+            return state.platformBalances.bonded[state.AVA_ASSET_ID] ?? ZeroBN
         },
 
-        walletPlatformBalanceBondedDeposited(state, getters, rootState): BN {
-            const avaxAssetID = state.AVA_ASSET_ID ?? ''
-            return state.platformBalances.bondedDeposited[avaxAssetID] ?? ZeroBN
+        walletPlatformBalanceBondedDeposited(state): BN {
+            return state.platformBalances.bondedDeposited[state.AVA_ASSET_ID] ?? ZeroBN
         },
 
         nftMintDict(state): IWalletNftMintDict {
@@ -744,10 +736,10 @@ const assets_module: Module<AssetsState, RootState> = {
                 return asset.id
             })
         },
-        AssetAVA(state, getters, rootState, rootGetters): AvaAsset | null {
+        AssetAVA(state, getters): AvaAsset | null {
             let walletBalanceDict = getters.walletAssetsDict
             let AVA_ASSET_ID = state.AVA_ASSET_ID
-            if (AVA_ASSET_ID) {
+            if (AVA_ASSET_ID !== '') {
                 if (walletBalanceDict[AVA_ASSET_ID]) {
                     return walletBalanceDict[AVA_ASSET_ID]
                 }

--- a/src/store/modules/assets/types.ts
+++ b/src/store/modules/assets/types.ts
@@ -11,7 +11,7 @@ export interface AssetsState {
     assets: AvaAsset[]
     assetsDict: AssetsDict
     platformBalances: PlatformBalances
-    AVA_ASSET_ID: string | null
+    AVA_ASSET_ID: string
     nftFams: AvaNftFamily[]
     nftFamsDict: NftFamilyDict
     balanceDict: IWalletBalanceDict

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -9,6 +9,7 @@ import { UTXO } from '@c4tplatform/caminojs/dist/apis/avm'
 import { UTXO as TxUTXO } from './modules/history/types'
 import { INetwork, WalletNameType, WalletType } from '@/js/wallets/types'
 import { KeystoreFileKeyType } from '@/js/IKeystore'
+import { ChainIdType } from '@/constants'
 
 export interface RootState {
     network: INetwork
@@ -84,6 +85,7 @@ export interface AssetType {
 }
 
 export interface IssueBatchTxInput {
+    chainId: ChainIdType
     toAddress: string
     memo?: Buffer
     orders: (ITransaction | UTXO)[]

--- a/src/views/wallet/Transfer.vue
+++ b/src/views/wallet/Transfer.vue
@@ -91,6 +91,16 @@
                                 >
                                     Sign Transaction
                                 </v-btn>
+                                <v-btn
+                                    depressed
+                                    class="button_primary"
+                                    :loading="isAjax"
+                                    :ripple="false"
+                                    @click="cancelMultisigTx"
+                                    block
+                                >
+                                    Cancel Transaction
+                                </v-btn>
                             </div>
                         </template>
                         <template v-else-if="!isConfirm">
@@ -426,6 +436,27 @@ export default class Transfer extends Vue {
             console.log(e)
             this.helpers.dispatchNotification({
                 message: this.$t('notifications.execute_multisig_transaction_error'),
+                type: 'error',
+            })
+        }
+    }
+
+    async cancelMultisigTx() {
+        try {
+            const wallet = this.wallet as MultisigWallet
+            if (this.pendingSendMultisigTX) {
+                // cancel from the wallet
+                await wallet.cancelExternal(this.pendingSendMultisigTX?.tx)
+                await this.$store.dispatch('Signavault/updateTransaction')
+                this.helpers.dispatchNotification({
+                    message: 'Transaction has been cancelled',
+                    type: 'success',
+                })
+            }
+        } catch (err) {
+            console.log(err)
+            this.helpers.dispatchNotification({
+                message: 'Cancelling the transaction failed',
                 type: 'error',
             })
         }

--- a/src/views/wallet/Transfer.vue
+++ b/src/views/wallet/Transfer.vue
@@ -208,7 +208,7 @@ import { UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
     },
 })
 export default class Transfer extends Vue {
-    formType: ChainIdType = 'X'
+    formType: ChainIdType = 'P'
     showAdvanced: boolean = false
     isAjax: boolean = false
     addressIn: string = ''
@@ -326,7 +326,7 @@ export default class Transfer extends Vue {
     }
 
     clearForm() {
-        if (!this.pendingSendMultisigTX) {
+        if (!this.pendingSendMultisigTX || this.formType !== 'P') {
             this.addressIn = ''
             this.memo = ''
         }
@@ -479,10 +479,12 @@ export default class Transfer extends Vue {
     }
     get canExecuteMultisigTx(): boolean {
         let signers = 0
+        let threshold = this.pendingSendMultisigTX?.tx?.threshold
         this.txOwners.forEach((owner) => {
             if (owner.signature) signers++
         })
-        return signers === this.pendingSendMultisigTX?.tx?.threshold
+        if (threshold) return signers >= threshold
+        return false
     }
     async updateMultisigTxDetails() {
         await this.$store.dispatch('Signavault/updateTransaction')

--- a/src/views/wallet/Transfer.vue
+++ b/src/views/wallet/Transfer.vue
@@ -367,7 +367,9 @@ export default class Transfer extends Vue {
     // multiSigLogicStart
     get pendingSendMultisigTX(): SignavaultTx | undefined {
         return this.$store.getters['Signavault/transactions'].find(
-            (item: any) => item?.tx?.alias === this.wallet.getAllAddressesP()[0]
+            (item: any) =>
+                item?.tx?.alias === this.wallet.getAllAddressesP()[0] &&
+                WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx) === 'BaseTx'
         )
     }
 

--- a/src/views/wallet/Transfer.vue
+++ b/src/views/wallet/Transfer.vue
@@ -8,7 +8,7 @@
             <FormC v-show="formType === 'C'">
                 <ChainInput v-model="formType" :disabled="isConfirm"></ChainInput>
             </FormC>
-            <div class="new_order_Form" v-show="formType === 'X'">
+            <div class="new_order_Form" v-show="formType !== 'C'">
                 <div class="lists">
                     <ChainInput v-model="formType" :disabled="isConfirm"></ChainInput>
                     <div>
@@ -17,6 +17,7 @@
                             ref="txList"
                             @change="updateTxList"
                             :disabled="isConfirm"
+                            :chainId="formType"
                         ></tx-list>
                         <template v-if="hasNFT">
                             <NftList
@@ -38,10 +39,10 @@
                         ></qr-input>
                     </div>
                     <div>
-                        <!--                        <template v-if="isConfirm && formMemo.length > 0">-->
-                        <!--                            <h4>Memo (Optional)</h4>-->
-                        <!--                            <p class="confirm_val">{{ formMemo }}</p>-->
-                        <!--                        </template>-->
+                        <template v-if="isConfirm && formMemo.length > 0">
+                            <h4>Memo (Optional)</h4>
+                            <p class="confirm_val">{{ formMemo }}</p>
+                        </template>
                         <h4 v-if="memo || !isConfirm">{{ $t('transfer.memo') }}</h4>
                         <textarea
                             class="memo"
@@ -55,7 +56,7 @@
                     <div class="fees">
                         <p>
                             {{ $t('transfer.fee_tx') }}
-                            <span>{{ txFee.toLocaleString(9) }} {{ nativeAssetSymbol }}</span>
+                            <span>{{ txFeeBig.toLocaleString(9) }} {{ nativeAssetSymbol }}</span>
                         </p>
                     </div>
                     <div class="checkout">
@@ -146,6 +147,7 @@ import TxSummary from '@/components/wallet/transfer/TxSummary.vue'
 import { priceDict, IssueBatchTxInput } from '@/store/types'
 import { WalletType } from '@/js/wallets/types'
 import { bnToBig } from '@/helpers/helper'
+import { WalletHelper } from '@/helpers/wallet_helper'
 import * as bip39 from 'bip39'
 import FormC from '@/components/wallet/transfer/FormC.vue'
 import { ChainIdType } from '@/constants'
@@ -153,6 +155,7 @@ import { ChainIdType } from '@/constants'
 import ChainInput from '@/components/wallet/transfer/ChainInput.vue'
 import AvaAsset from '../../js/AvaAsset'
 import { TxState } from '@/components/wallet/earn/ChainTransfer/types'
+import { SignatureError } from '@c4tplatform/caminojs/dist/common'
 @Component({
     components: {
         FaucetLink,
@@ -229,7 +232,7 @@ export default class Transfer extends Vue {
 
         let chain = addr.split('-')
 
-        if (chain[0] !== 'X') {
+        if (chain[0] !== this.formType[0]) {
             err.push('Invalid address. You can only send to other X addresses.')
         }
 
@@ -293,7 +296,7 @@ export default class Transfer extends Vue {
         }
     }
 
-    async onsuccess(tx: string) {
+    async onSuccess(tx: string) {
         this.isAjax = false
         this.isSuccess = true
         this.txId = tx
@@ -319,7 +322,7 @@ export default class Transfer extends Vue {
         }
     }
 
-    onerror(err: any) {
+    onError(err: any) {
         this.err = err
         this.isAjax = false
         let { dispatchNotification } = this.globalHelper()
@@ -336,6 +339,7 @@ export default class Transfer extends Vue {
         let sumArray: (ITransaction | UTXO)[] = [...this.formOrders, ...this.formNftOrders]
 
         let txList: IssueBatchTxInput = {
+            chainId: this.formType,
             toAddress: this.formAddress,
             memo: Buffer.from(this.formMemo),
             orders: sumArray,
@@ -349,12 +353,33 @@ export default class Transfer extends Vue {
                 this.txId = res
             })
             .catch((err) => {
-                this.onerror(err)
+                if (err instanceof SignatureError) {
+                    this.$store.dispatch('Notifications/add', {
+                        type: 'info',
+                        title: 'Multisignature',
+                        message: err.message,
+                    })
+                    setTimeout(() => {
+                        this.$store.dispatch('Assets/updateUTXOs')
+                        this.$store.dispatch('Signavault/updateTransaction').then(() => {
+                            this.$store.dispatch('History/updateMultisigTransactionHistory')
+                        })
+                    }, 3000)
+                    this.canSendAgain = false
+                    this.isAjax = false
+                    this.isSuccess = true
+                    this.txState = TxState.success
+                }
+                this.onError(err)
             })
     }
 
     async waitTxConfirm(txId: string) {
-        let status = await ava.XChain().getTxStatus(txId)
+        let status =
+            this.formType === 'P'
+                ? await ava.PChain().getTxStatus(txId)
+                : await ava.XChain().getTxStatus(txId)
+
         if (status === 'Unknown' || status === 'Processing') {
             // if not confirmed ask again
             setTimeout(() => {
@@ -368,7 +393,7 @@ export default class Transfer extends Vue {
         } else {
             // If success display success page
             this.txState = TxState.success
-            this.onsuccess(txId)
+            this.onSuccess(txId)
         }
     }
 
@@ -378,8 +403,7 @@ export default class Transfer extends Vue {
     }
 
     get hasNFT(): boolean {
-        // return this.$store.getters.walletNftUTXOs.length > 0
-        return this.$store.state.Assets.nftUTXOs.length > 0
+        return this.formType === 'X' && this.$store.state.Assets.nftUTXOs.length > 0
     }
 
     get faucetLink() {
@@ -433,9 +457,20 @@ export default class Transfer extends Vue {
         return this.$store.state.activeWallet
     }
 
-    get txFee(): Big {
-        let fee = ava.XChain().getTxFee()
-        return bnToBig(fee, 9)
+    get txFee(): BN {
+        return this.formType === 'P' ? ava.PChain().getTxFee() : ava.XChain().getTxFee()
+    }
+
+    get txFeeBig(): Big {
+        return bnToBig(this.txFee, 9)
+    }
+
+    get totalUSD(): Big {
+        let totalAsset = this.avaxTxSize.add(this.txFee)
+        let bigAmt = bnToBig(totalAsset, 9)
+        let usdPrice = this.priceDict.usd
+        let usdBig = bigAmt.times(usdPrice)
+        return usdBig
     }
 
     get addresses() {
@@ -462,12 +497,8 @@ export default class Transfer extends Vue {
         this.clearForm()
 
         if (this.$route.query.chain) {
-            let chain = this.$route.query.chain as string
-            if (chain === 'X') {
-                this.formType = 'X'
-            } else {
-                this.formType = 'C'
-            }
+            let chain = this.$route.query.chain as ChainIdType
+            if (['P', 'X', 'C'].includes(chain)) this.formType = chain
         }
 
         if (this.$route.query.nft) {
@@ -555,7 +586,6 @@ h4 {
     margin-top: 4px;
     display: flex;
     background-color: #404040;
-    /*cursor: pointer;*/
 }
 .readerBut button {
     opacity: 0.6;
@@ -593,17 +623,12 @@ h4 {
 }
 
 .new_order_Form > div {
-    /*padding: 10px 0;*/
     margin-bottom: 15px;
 }
+
 .lists {
-    /*padding-right: 45px;*/
     border-right: 1px solid var(--bg-light);
     grid-column: 1/3;
-
-    /*> div{*/
-    /*    margin: 14px 0;*/
-    /*}*/
 }
 
 .tx_list {
@@ -624,9 +649,6 @@ h4 {
 
 .fees span {
     float: right;
-}
-
-.to_address {
 }
 
 label {
@@ -664,16 +686,6 @@ label {
     word-break: break-all;
     padding: 8px 16px;
 }
-
-//@media only screen and (max-width: 600px) {
-//    .order_form {
-//        display: block;
-//    }
-//    .asset_select button {
-//        flex-grow: 1;
-//        word-break: break-word;
-//    }
-//}
 
 @include mixins.medium-device {
     .new_order_Form {

--- a/src/views/wallet/Transfer.vue
+++ b/src/views/wallet/Transfer.vue
@@ -456,6 +456,13 @@ export default class Transfer extends Vue {
             unsignedTx.fromBuffer(Buffer.from(this.pendingSendMultisigTX.tx?.unsignedTx, 'hex'))
             const utx = unsignedTx.getTransaction()
             this.memo = utx.getMemo().toString()
+
+            const toAddress = WalletHelper.getToAddressFromUtx(
+                unsignedTx,
+                this.wallet.getAllAddressesP()[0]
+            )
+
+            // TODO @Achraf
         }
     }
     async beforeMount() {

--- a/src/views/wallet/Validator.vue
+++ b/src/views/wallet/Validator.vue
@@ -141,7 +141,11 @@ export default class Validator extends Vue {
 
     get multisigPendingNodeTx(): SignavaultTx | undefined {
         return this.$store.getters['Signavault/transactions'].find(
-            (item: any) => item?.tx?.alias === this.addresses[0]
+            (item: any) =>
+                item?.tx?.alias === this.addresses[0] &&
+                ['CaminoAddValidatorTx', 'RegisterNodeTx'].includes(
+                    WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx)
+                )
         )
     }
 


### PR DESCRIPTION
this PR adds sending funds on the P-chain with the following:
- added a new button in the Send section identical to the ones used in the X-Chain transfer for sending funds on the P-Chain 
- the buttons in the send component are based on the status of the TX and the type of the wallet
- added a refresh button to update the state of the transaction from Signavault