### PR TITLE
fix(e2e): modify e2e tests to adopt to the latest ui

### DIFF
--- a/cypress/e2e/send/send_p_chain_mock.cy.ts
+++ b/cypress/e2e/send/send_p_chain_mock.cy.ts
@@ -106,7 +106,7 @@ describe('Send: P to P transfer by already owned balance', () => {
             cy.get('.button_primary').eq(1).click({ force: true })
 
             cy.wait('@issueTx').then(() => {
-                cy.get('div.new_order_Form > div:nth-child(2) > div.checkout > p').should(($p) => {
+                cy.get('p[data-cy="transfer-tx-status"]').should(($p) => {
                     expect($p.first()).to.contain('Transaction Sent')
                 })
             })

--- a/cypress/e2e/send/send_x-chain_mock.cy.ts
+++ b/cypress/e2e/send/send_x-chain_mock.cy.ts
@@ -122,7 +122,7 @@ describe('Send transaction with x-chain balance', () => {
 
                 // expect display txID
                 cy.wait('@issueTx').then(() => {
-                    cy.get('div.new_order_Form > div:nth-child(2) > div.checkout > p').should(($p) => {
+                    cy.get('p[data-cy="transfer-tx-status"]').should(($p) => {
                         expect($p.first()).to.contain('Transaction Sent')
                     })
                 })

--- a/src/views/wallet/Transfer.vue
+++ b/src/views/wallet/Transfer.vue
@@ -146,7 +146,7 @@
                                 </p>
                             </div>
                             <div v-else>
-                                <p style="color: var(--success)">
+                                <p data-cy="transfer-tx-status" style="color: var(--success)">
                                     <fa icon="check-circle"></fa>
                                     Transaction Sent
                                 </p>


### PR DESCRIPTION
### Why this PR
To fix and prevent e2e tests failed when ui changed

### What modified
- add cypress test attribute `data-cy` to the test target
- modify related tests to use `data-cy` attribute instead of querying dom by hierarchy selectors