### PR TITLE
fix decimals modal rewards

### DIFF
--- a/src/components/wallet/earn/Validate/ModalClaimReward.vue
+++ b/src/components/wallet/earn/Validate/ModalClaimReward.vue
@@ -112,7 +112,7 @@ export default class ModalClaimReward extends Vue {
                 this.close()
                 this.$emit('beforeCloseModal', false)
             } else {
-                this.confirmedClaimedAmountText = new BN(this.amount).toString()
+                this.confirmedClaimedAmountText = SDK.bnToBigAvaxX(new BN(this.amount)).toString()
                 this.claimed = true
             }
         } catch (e) {


### PR DESCRIPTION
When claiming the Validator rewards, it shows the decimals, since previously the value was not shown in CAMS but in Weis