### PR TITLE
Disable obsolete cypress test

### DIFF
--- a/cypress/e2e/access_wallet_using_mnemonic.cy.ts
+++ b/cypress/e2e/access_wallet_using_mnemonic.cy.ts
@@ -7,7 +7,7 @@ describe('Wallet Access Mnemonic', () => {
         cy.visit('/')
     })
 
-    it('open suite/open wallet using mnemonic', () => {
+    it.skip('open suite/open wallet using mnemonic', () => {
         addKopernikusNetwork(cy)
         //changeNetwork(cy);
         accessWallet(cy, 'mnemonic')

--- a/cypress/e2e/access_wallet_using_pk.cy.ts
+++ b/cypress/e2e/access_wallet_using_pk.cy.ts
@@ -5,7 +5,7 @@ describe('access wallet', () => {
     before(() => {
         cy.visit('/')
     })
-    it('Wallet access private key ', () => {
+    it.skip('Wallet access private key ', () => {
         //changeNetwork(cy);
         addKopernikusNetwork(cy)
         accessWallet(cy, 'privateKey')

--- a/cypress/e2e/create_wallet.cy.ts
+++ b/cypress/e2e/create_wallet.cy.ts
@@ -8,7 +8,7 @@ describe('Wallet Creation', () => {
         cy.visit('/')
     })
 
-    it('open suite/create wallet', () => {
+    it.skip('open suite/create wallet', () => {
         addKopernikusNetwork(cy);
         //changeNetwork(cy)
         cy.wait(2000)

--- a/cypress/e2e/cross-chain/cross_chain_c_to_x_mock.cy.ts
+++ b/cypress/e2e/cross-chain/cross_chain_c_to_x_mock.cy.ts
@@ -10,82 +10,82 @@ import {
 
 describe('Cross chain: C to X', () => {
     beforeEach(() => {
-        cy.loginWalletWith('privateKey')
+        // cy.loginWalletWith('privateKey')
 
-        // RPC aliases
-        cy.intercept('**/ext/bc/C/rpc', (request) => {
-            if (request.body.method === 'eth_baseFee') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/eth_base_fee.json'
-                })
-                request.alias = 'apiBaseFee'
-            } else if (request.body.method === 'eth_getBalance') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: '0x1b0cf699489af08800',
-                    },
-                })
-            }
-        })
+        // // RPC aliases
+        // cy.intercept('**/ext/bc/C/rpc', (request) => {
+        //     if (request.body.method === 'eth_baseFee') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/eth_base_fee.json'
+        //         })
+        //         request.alias = 'apiBaseFee'
+        //     } else if (request.body.method === 'eth_getBalance') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: '0x1b0cf699489af08800',
+        //             },
+        //         })
+        //     }
+        // })
 
-        cy.intercept('POST', '**/ext/bc/X', (request) => {
-            if (request.body.method === 'avm.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_issue_tx.json'
-                })
-                request.alias = 'apiImportX'
-            }
+        // cy.intercept('POST', '**/ext/bc/X', (request) => {
+        //     if (request.body.method === 'avm.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_issue_tx.json'
+        //         })
+        //         request.alias = 'apiImportX'
+        //     }
             
-            if (request.body.method === 'avm.getTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_get_tx_status.json'
-                })
-                request.alias = 'apiImportXStatus'
-            }
+        //     if (request.body.method === 'avm.getTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_get_tx_status.json'
+        //         })
+        //         request.alias = 'apiImportXStatus'
+        //     }
 
-            if (request.body.method === 'avm.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_getUTXOs.json'
-                })
-            }
+        //     if (request.body.method === 'avm.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_getUTXOs.json'
+        //         })
+        //     }
             
-        })
-        cy.intercept('POST', '**/ext/bc/C/avax', (request) => {
-            if (request.body.method === 'avax.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avax_getUTXOs.json'
-                })
-            } else if (request.body.method === 'avax.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avax_issue_tx.json'
-                })
-                request.alias = 'apiExportC'
-            } else if (request.body.method === 'avax.getAtomicTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avax_get_atomic_tx_status.json'
-                })
-                request.alias = 'apiExportCStatus'
-            }
-        })
-        // Switch to cross chain
-        cy.switchToWalletFunctionTab('Cross Chain')
-        // Make sure successfully switched to the Cross Chain tab
-        cy.get('.wallet_main > #wallet_router > .header')
-            .find('h1')
-            .should('have.text', 'Cross Chain')
+        // })
+        // cy.intercept('POST', '**/ext/bc/C/avax', (request) => {
+        //     if (request.body.method === 'avax.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avax_getUTXOs.json'
+        //         })
+        //     } else if (request.body.method === 'avax.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avax_issue_tx.json'
+        //         })
+        //         request.alias = 'apiExportC'
+        //     } else if (request.body.method === 'avax.getAtomicTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avax_get_atomic_tx_status.json'
+        //         })
+        //         request.alias = 'apiExportCStatus'
+        //     }
+        // })
+        // // Switch to cross chain
+        // cy.switchToWalletFunctionTab('Cross Chain')
+        // // Make sure successfully switched to the Cross Chain tab
+        // cy.get('.wallet_main > #wallet_router > .header')
+        //     .find('h1')
+        //     .should('have.text', 'Cross Chain')
     })
 
-    it('export CAM from C to X', () => {
+    it.skip('export CAM from C to X', () => {
         cy.get('label').contains('Source Chain').siblings('select').first().as('selectSource')
         cy.get('label')
             .contains('Destination Chain')

--- a/cypress/e2e/cross-chain/cross_chain_x_to_c_mock.cy.ts
+++ b/cypress/e2e/cross-chain/cross_chain_x_to_c_mock.cy.ts
@@ -10,72 +10,72 @@ import {
 
 describe('Cross chain: X to C', () => {
     beforeEach(() => {
-        cy.loginWalletWith('privateKey')
+        // cy.loginWalletWith('privateKey')
 
-        // RPC aliases
-        cy.intercept('**/ext/bc/C/rpc', (request) => {
-            if (request.body.method === 'eth_baseFee') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/eth_base_fee.json'
-                })
-                request.alias = 'apiBaseFee'
-            }
-        })
-        cy.intercept('POST', '**/ext/bc/X', (request) => {
-            if (request.body.method == 'avm.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_getUTXOs.json'
-                })
-            } else if (request.body.method === 'avm.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_issue_tx.json'
-                })
-                request.alias = 'apiExportX'
-            } else if (request.body.method === 'avm.getTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_get_tx_status.json'
-                })
-                request.alias = 'apiExportXStatus'
-            }
-        })
-        cy.intercept('POST', '**/ext/bc/C/avax', (request) => {
-            if (request.body.method === 'avax.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avax_issue_tx.json'
-                })
-                request.alias = 'apiImportC'
-            } 
+        // // RPC aliases
+        // cy.intercept('**/ext/bc/C/rpc', (request) => {
+        //     if (request.body.method === 'eth_baseFee') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/eth_base_fee.json'
+        //         })
+        //         request.alias = 'apiBaseFee'
+        //     }
+        // })
+        // cy.intercept('POST', '**/ext/bc/X', (request) => {
+        //     if (request.body.method == 'avm.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_getUTXOs.json'
+        //         })
+        //     } else if (request.body.method === 'avm.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_issue_tx.json'
+        //         })
+        //         request.alias = 'apiExportX'
+        //     } else if (request.body.method === 'avm.getTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_get_tx_status.json'
+        //         })
+        //         request.alias = 'apiExportXStatus'
+        //     }
+        // })
+        // cy.intercept('POST', '**/ext/bc/C/avax', (request) => {
+        //     if (request.body.method === 'avax.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avax_issue_tx.json'
+        //         })
+        //         request.alias = 'apiImportC'
+        //     } 
 
-            if (request.body.method === 'avax.getAtomicTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avax_get_atomic_tx_status.json'
-                })
-                request.alias = 'apiImportCStatus'
-            }
+        //     if (request.body.method === 'avax.getAtomicTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avax_get_atomic_tx_status.json'
+        //         })
+        //         request.alias = 'apiImportCStatus'
+        //     }
 
-            if (request.body.method === 'avax.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avax_getUTXOs.json'
-                })
-            }
-        })
+        //     if (request.body.method === 'avax.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avax_getUTXOs.json'
+        //         })
+        //     }
+        // })
 
-        // Switch to cross chain
-        cy.switchToWalletFunctionTab('Cross Chain')
-        // Make sure successfully switched to the Cross Chain tab
-        cy.get('.wallet_main > #wallet_router > .header')
-            .find('h1')
-            .should('have.text', 'Cross Chain')
+        // // Switch to cross chain
+        // cy.switchToWalletFunctionTab('Cross Chain')
+        // // Make sure successfully switched to the Cross Chain tab
+        // cy.get('.wallet_main > #wallet_router > .header')
+        //     .find('h1')
+        //     .should('have.text', 'Cross Chain')
     })
 
-    it('export CAM from X to C', () => {
+    it.skip('export CAM from X to C', () => {
         cy.get('label').contains('Source Chain').siblings('select').first().as('selectSource')
         cy.get('label')
             .contains('Destination Chain')

--- a/cypress/e2e/cross-chain/cross_chain_x_to_p_mock.cy.ts
+++ b/cypress/e2e/cross-chain/cross_chain_x_to_p_mock.cy.ts
@@ -5,63 +5,63 @@ import {
 
 describe('Cross chain: X to P', () => {
     beforeEach(() => {
-        cy.loginWalletWith('privateKey')
+        // cy.loginWalletWith('privateKey')
 
-        // RPC aliases
-        cy.intercept('POST', '**/ext/bc/X', (request) => {
-            if (request.body.method == 'avm.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_getUTXOs.json'
-                })
-            } else if (request.body.method === 'avm.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_issue_tx.json'
-                })
-                request.alias = 'apiExportX'
-            } else if (request.body.method === 'avm.getTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_get_tx_status.json'
-                })
-                request.alias = 'apiExportXStatus'
-            }
-        })
-        cy.intercept('POST', '**/ext/bc/P', (request) => {
-            if (request.body.method === 'platform.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/platform_issue_tx.json'
-                })
-                request.alias = 'apiImportP'
-            }  
+        // // RPC aliases
+        // cy.intercept('POST', '**/ext/bc/X', (request) => {
+        //     if (request.body.method == 'avm.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_getUTXOs.json'
+        //         })
+        //     } else if (request.body.method === 'avm.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_issue_tx.json'
+        //         })
+        //         request.alias = 'apiExportX'
+        //     } else if (request.body.method === 'avm.getTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_get_tx_status.json'
+        //         })
+        //         request.alias = 'apiExportXStatus'
+        //     }
+        // })
+        // cy.intercept('POST', '**/ext/bc/P', (request) => {
+        //     if (request.body.method === 'platform.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/platform_issue_tx.json'
+        //         })
+        //         request.alias = 'apiImportP'
+        //     }  
             
-            if (request.body.method === 'platform.getTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/platform_get_tx_status.json'
-                })
-                request.alias = 'apiImportPStatus'
-            }
+        //     if (request.body.method === 'platform.getTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/platform_get_tx_status.json'
+        //         })
+        //         request.alias = 'apiImportPStatus'
+        //     }
 
-            if (request.body.method === 'platform.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/platform_getUTXOs.json'
-                })
-            }
-        })
+        //     if (request.body.method === 'platform.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/platform_getUTXOs.json'
+        //         })
+        //     }
+        // })
 
-        // Switch to cross chain
-        cy.switchToWalletFunctionTab('Cross Chain')
-        // Make sure successfully switched to the Cross Chain tab
-        cy.get('.wallet_main > #wallet_router > .header')
-            .find('h1')
-            .should('have.text', 'Cross Chain')
+        // // Switch to cross chain
+        // cy.switchToWalletFunctionTab('Cross Chain')
+        // // Make sure successfully switched to the Cross Chain tab
+        // cy.get('.wallet_main > #wallet_router > .header')
+        //     .find('h1')
+        //     .should('have.text', 'Cross Chain')
     })
 
-    it('export CAM from X to P', () => {
+    it.skip('export CAM from X to P', () => {
         cy.get('label').contains('Source Chain').siblings('select').first().as('selectSource')
         cy.get('label')
             .contains('Destination Chain')

--- a/cypress/e2e/multisig_switch_wallet.cy.ts
+++ b/cypress/e2e/multisig_switch_wallet.cy.ts
@@ -1,122 +1,122 @@
 describe('multisig: switch wellet', () => {
     beforeEach(() => {
-        cy.loginWalletWith('privateKey', 'multisigAliasPrivateKey')
-        cy.switchToWalletFunctionTab('Manage Keys')
-        cy.intercept('GET', '**/v2/multisigalias/*', (request) => {
-            request.reply({
-                statusCode: 200,
-                body: {
-                    alias: [
-                        'kopernikus18gw475en5h5jvtkslp7xqed7t7ugq6rmc4zrvh',
-                        'kopernikus12tqp70mm2ak9lfh9j9eqyldkpey5ntlxduct37',
-                        'kopernikus1whcusz08xtlx0dgmrsxqt7a8gupgzd32r5stpy',
-                    ],
-                },
-            })
-        })
+        // cy.loginWalletWith('privateKey', 'multisigAliasPrivateKey')
+        // cy.switchToWalletFunctionTab('Manage Keys')
+        // cy.intercept('GET', '**/v2/multisigalias/*', (request) => {
+        //     request.reply({
+        //         statusCode: 200,
+        //         body: {
+        //             alias: [
+        //                 'kopernikus18gw475en5h5jvtkslp7xqed7t7ugq6rmc4zrvh',
+        //                 'kopernikus12tqp70mm2ak9lfh9j9eqyldkpey5ntlxduct37',
+        //                 'kopernikus1whcusz08xtlx0dgmrsxqt7a8gupgzd32r5stpy',
+        //             ],
+        //         },
+        //     })
+        // })
 
-        cy.intercept('POST', '**/ext/bc/P', (request) => {
-            if (request.body.method === 'platform.getMultisigAlias') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: {
-                            addresses: [
-                                'P-kopernikus1qfyvkqnv8yd9rmlf6sv0gdx20dgg4erslxurav',
-                                'P-kopernikus1yk9lw48um0r0rn9ydf9fhjfwwfq0qh7qpytjcr',
-                                'P-kopernikus1fvr4nd743ew0gcy00se24hp2ecpmk4h7lhkll4',
-                                'P-kopernikus1dgrg4j4p5e6k5jn8080n6333r934pyum0zgczg',
-                                'P-kopernikus10xf9u6we06ljq20jtq90hj0f6q8l2psp0njqmu',
-                                'P-kopernikus102uap4au55t22m797rr030wyrw0jlgw25ut8vj',
-                                'P-kopernikus1c35zu69gd42yu9ecrptzwf0z9g7fhfvrmrjgam',
-                                'P-kopernikus1maff3tql60ndkwn9mvz06ssywvag4uf48el62q',
-                                'P-kopernikus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwk2nm7k0',
-                            ],
-                            memo: '0x31303031',
-                            threshold: '2',
-                        },
-                    },
-                })
-            }
-        })
+        // cy.intercept('POST', '**/ext/bc/P', (request) => {
+        //     if (request.body.method === 'platform.getMultisigAlias') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: {
+        //                     addresses: [
+        //                         'P-kopernikus1qfyvkqnv8yd9rmlf6sv0gdx20dgg4erslxurav',
+        //                         'P-kopernikus1yk9lw48um0r0rn9ydf9fhjfwwfq0qh7qpytjcr',
+        //                         'P-kopernikus1fvr4nd743ew0gcy00se24hp2ecpmk4h7lhkll4',
+        //                         'P-kopernikus1dgrg4j4p5e6k5jn8080n6333r934pyum0zgczg',
+        //                         'P-kopernikus10xf9u6we06ljq20jtq90hj0f6q8l2psp0njqmu',
+        //                         'P-kopernikus102uap4au55t22m797rr030wyrw0jlgw25ut8vj',
+        //                         'P-kopernikus1c35zu69gd42yu9ecrptzwf0z9g7fhfvrmrjgam',
+        //                         'P-kopernikus1maff3tql60ndkwn9mvz06ssywvag4uf48el62q',
+        //                         'P-kopernikus1lmwsgy9zv8hyxwsek0pvsq7cpejtkvwk2nm7k0',
+        //                     ],
+        //                     memo: '0x31303031',
+        //                     threshold: '2',
+        //                 },
+        //             },
+        //         })
+        //     }
+        // })
 
-        cy.intercept('POST', '**/ext/bc/X', (request) => {
-            if (request.body.method === 'avm.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: {
-                            encoding: 'hex',
-                            endIndex: {
-                                address: 'X-kopernikus1maff3tql60ndkwn9mvz06ssywvag4uf48el62q',
-                                utxo: '5EHYBsL9HbHS1yHgp9dQCYZKy7C8VB3J4roTQ5FBJmqr65G8T',
-                            },
-                            numFetched: '2',
-                            utxos: [
-                                '0x0000bd2fcdf4cb5f5cdad2516397155d28474cab585134824db35107af86f5180bdf000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000070000001694a615a800000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af13523b9a8a6',
-                                '0x0000b392b7aabdb825257857ac7bd087fdb8c10290ac561c561a8c1e71346085091f000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000000000098968000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af1358dc4f97d',
-                                '0x000074586670c1bf26ffbd7af84e4298a3e19c05fb8235fc2f19459fe2f930a283a4000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000000003b9aca0000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af135e77d4535',
-                                '0x00005d59e292133376a3ec90f6fb64e6f77d0745cced9d15ea861ee0c95a636705fc000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000000003b9aca0000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af1356e6bd739',
-                            ],
-                        },
-                    },
-                })
-            }
-        })
+        // cy.intercept('POST', '**/ext/bc/X', (request) => {
+        //     if (request.body.method === 'avm.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: {
+        //                     encoding: 'hex',
+        //                     endIndex: {
+        //                         address: 'X-kopernikus1maff3tql60ndkwn9mvz06ssywvag4uf48el62q',
+        //                         utxo: '5EHYBsL9HbHS1yHgp9dQCYZKy7C8VB3J4roTQ5FBJmqr65G8T',
+        //                     },
+        //                     numFetched: '2',
+        //                     utxos: [
+        //                         '0x0000bd2fcdf4cb5f5cdad2516397155d28474cab585134824db35107af86f5180bdf000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000070000001694a615a800000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af13523b9a8a6',
+        //                         '0x0000b392b7aabdb825257857ac7bd087fdb8c10290ac561c561a8c1e71346085091f000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000000000098968000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af1358dc4f97d',
+        //                         '0x000074586670c1bf26ffbd7af84e4298a3e19c05fb8235fc2f19459fe2f930a283a4000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000000003b9aca0000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af135e77d4535',
+        //                         '0x00005d59e292133376a3ec90f6fb64e6f77d0745cced9d15ea861ee0c95a636705fc000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000000003b9aca0000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af1356e6bd739',
+        //                     ],
+        //                 },
+        //             },
+        //         })
+        //     }
+        // })
 
-        cy.intercept('POST', '**/ext/bc/P', (request) => {
-            if (request.body.method === 'platform.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: {
-                            encoding: 'hex',
-                            endIndex: {
-                                address: 'P-kopernikus1maff3tql60ndkwn9mvz06ssywvag4uf48el62q',
-                                utxo: 'qisCyQZdJWn1EWbuLoQij299tBKqd4GgKvzfHrCX8cCBxyBcR',
-                            },
-                            numFetched: '2',
-                            utxos: [
-                                '0x000081a4fc69d1b7243124b64bea29520a1f8911e16df6b395493b129c4a025f078d000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000008e9bdc4cae800000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af1355aca3425',
-                                '0x000060591c8a2ce15345374e00462c6a1aba2f5e8a7891a85df37d6a95abbd040ba3000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f760000000700038d7ea4c6800000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af135d138ae14',
-                            ],
-                        },
-                    },
-                })
-            }
-        })
+        // cy.intercept('POST', '**/ext/bc/P', (request) => {
+        //     if (request.body.method === 'platform.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: {
+        //                     encoding: 'hex',
+        //                     endIndex: {
+        //                         address: 'P-kopernikus1maff3tql60ndkwn9mvz06ssywvag4uf48el62q',
+        //                         utxo: 'qisCyQZdJWn1EWbuLoQij299tBKqd4GgKvzfHrCX8cCBxyBcR',
+        //                     },
+        //                     numFetched: '2',
+        //                     utxos: [
+        //                         '0x000081a4fc69d1b7243124b64bea29520a1f8911e16df6b395493b129c4a025f078d000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f7600000007000008e9bdc4cae800000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af1355aca3425',
+        //                         '0x000060591c8a2ce15345374e00462c6a1aba2f5e8a7891a85df37d6a95abbd040ba3000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f760000000700038d7ea4c6800000000000000000000000000100000001df5298ac1fd3e6db3a65db04fd4204733a8af135d138ae14',
+        //                     ],
+        //                 },
+        //             },
+        //         })
+        //     }
+        // })
 
-        cy.intercept('POST', '**/ext/bc/C/rpc', (request) => {
-            if (request.body.method === 'eth_getBalance') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: '0x57971e715b9a0e000',
-                    },
-                })
-                request.alias = 'firstPlatformGetUTXOs'
-            }
-        })
+        // cy.intercept('POST', '**/ext/bc/C/rpc', (request) => {
+        //     if (request.body.method === 'eth_getBalance') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: '0x57971e715b9a0e000',
+        //             },
+        //         })
+        //         request.alias = 'firstPlatformGetUTXOs'
+        //     }
+        // })
 
-        cy.get('[data-cy="btn-show-breakdown"]').click()
-        cy.get('[data-cy="top-balance-available-X"]').as('balanceX')
-        cy.get('[data-cy="top-balance-available-P"]').as('balanceP')
-        cy.get('[data-cy="top-balance-available-C"]').as('balanceC')
-        cy.get('[data-cy="wallet_balance"]').as('totalBalance')
-        cy.get('.alt_breakdown').find('div').eq(1).find('p').eq(0).as('Deposited')
+        // cy.get('[data-cy="btn-show-breakdown"]').click()
+        // cy.get('[data-cy="top-balance-available-X"]').as('balanceX')
+        // cy.get('[data-cy="top-balance-available-P"]').as('balanceP')
+        // cy.get('[data-cy="top-balance-available-C"]').as('balanceC')
+        // cy.get('[data-cy="wallet_balance"]').as('totalBalance')
+        // cy.get('.alt_breakdown').find('div').eq(1).find('p').eq(0).as('Deposited')
 
-        verifyBalance()
+        // verifyBalance()
     })
 
-    it('change to active other key', () => {
+    it.skip('change to active other key', () => {
         cy.get('.button_container').find('button').eq(1).click()
         cy.get('.v-slide-group__content').find('div').eq(5).click()
         cy.get('.fetch_button').click()

--- a/cypress/e2e/send/send_chain_mock.cy.ts
+++ b/cypress/e2e/send/send_chain_mock.cy.ts
@@ -82,7 +82,7 @@ describe('Send: C to C transfer by already owned balance', () => {
         })
     })
 
-    it('verify Fee from C to C', () => {
+    it.skip('verify Fee from C to C', () => {
         cy.get<string>('@ownChainBalance').then((balance) => {
             if (balance > 0) {
                 // Input C Chain Addr
@@ -175,35 +175,35 @@ describe('Send: C to C transfer by already owned balance', () => {
 
 describe('Send: C to C transfer by not balance', () => {
     beforeEach(() => {
-        cy.loginWalletWith('privateKey', 'privateKeyZeroBalance')
+        // cy.loginWalletWith('privateKey', 'privateKeyZeroBalance')
 
-        cy.get('[data-cy="wallet_transfer"]').click().should('have.class', 'router-link-active')
+        // cy.get('[data-cy="wallet_transfer"]').click().should('have.class', 'router-link-active')
 
-        // Hidden Show Breakdown
-        cy.get('.breakdown_toggle').first().click()
+        // // Hidden Show Breakdown
+        // cy.get('.breakdown_toggle').first().click()
 
-        // Get Own C-Chain Balance
-        cy.get('.alt_breakdown > :nth-child(1) > :nth-child(6)')
-            .invoke('text')
-            .then((balance) => cy.wrap(balance.replace(/\sCAM/g, '')).as('ownChainBalance'))
+        // // Get Own C-Chain Balance
+        // cy.get('.alt_breakdown > :nth-child(1) > :nth-child(6)')
+        //     .invoke('text')
+        //     .then((balance) => cy.wrap(balance.replace(/\sCAM/g, '')).as('ownChainBalance'))
 
-        // Switch Source Chain to C
-        cy.get('.lists > div:nth-child(1) > .chain_select').contains('C').click()
+        // // Switch Source Chain to C
+        // cy.get('.lists > div:nth-child(1) > .chain_select').contains('C').click()
 
-        // Input More than Own Amount
-        cy.get('.evm_input_dropdown > .col_in > .col_big_in > input').as('inputAmount')
-        cy.get<string>('@ownChainBalance').then((balance) => {
-            const increaseBalance = parseFloat(balance) + 1
-            cy.get('@inputAmount')
-                .type(`${increaseBalance}{enter}`)
-                .then((input) => {
-                    const amount = parseFloat(input.val() as string)
-                    expect(amount).to.lte(parseFloat(balance))
-                })
-        })
+        // // Input More than Own Amount
+        // cy.get('.evm_input_dropdown > .col_in > .col_big_in > input').as('inputAmount')
+        // cy.get<string>('@ownChainBalance').then((balance) => {
+        //     const increaseBalance = parseFloat(balance) + 1
+        //     cy.get('@inputAmount')
+        //         .type(`${increaseBalance}{enter}`)
+        //         .then((input) => {
+        //             const amount = parseFloat(input.val() as string)
+        //             expect(amount).to.lte(parseFloat(balance))
+        //         })
+        // })
     })
 
-    it('verify Fee from C to C', () => {
+    it.skip('verify Fee from C to C', () => {
         // Input C Chain Addr
         cy.get('.bottom_tabs > .chain_select > button:nth-child(3)').click()
         cy.get('[data-cy="wallet_address"]').invoke('text').as('chainAddress')

--- a/cypress/e2e/send/send_p_chain_mock.cy.ts
+++ b/cypress/e2e/send/send_p_chain_mock.cy.ts
@@ -1,96 +1,96 @@
 describe('Send: P to P transfer by already owned balance', () => {
     beforeEach(() => {
-        cy.loginWalletWith('privateKey')
+        // cy.loginWalletWith('privateKey')
 
-        cy.intercept('POST', '**/ext/bc/P', (request) => {
-            if (request.body.method == 'platform.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: {
-                            'encoding': 'hex',
-                            'endIndex': {
-                                'address': 'P-kopernikus1e0vfxvw5hvy00haua96zzdfgxwv6nq8ptng5h7',
-                                'utxo': 'Uex3zijzgoXR2D6d8YyLF6Tc3xJcJdD6JxYRpHH3zhf8t9jYy'
-                            },
-                            'numFetched': '1',
-                            'utxos': ['0x0000a47114e8ae68c763c5320ec6d316854769e95f149354b9ac67e999279b64478f000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000070000011f4fe4ab0000000000000000000000000100000001cbd89331d4bb08f7dfbce9742135283399a980e13f46a7ea']
-                        }
-                    },
-                })
-            } else if (request.body.method == 'platform.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: {
-                            'txID': '2FRShpVijngNW1FF12ws7DE43Su7ggUXboTMQtRdGQeZP7U1ZL'
-                        }
-                    },
-                })
-                request.alias = 'issueTx'
-            } else if (request.body.method == 'platform.getTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: {
-                            'status': 'Committed'
-                        }
-                    },
-                })
-            } else if (request.body.method == 'platform.spend') {
-                request.reply({
-                    statusCode: 200,
-                    body: {
-                        id: request.body.id,
-                        jsonrpc: '2.0',
-                        result: {
-                            ins: '0x000000000001ee9167f3ba0d85ed4584d8ed157ea1672836c8026703f4912141cd0166cfaaf5000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000050000011f4ff3ed4000000001000000009d632f28',
-                            outs: '0x0000000000015e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000070000011f4fe4ab0000000000000000000000000100000001cbd89331d4bb08f7dfbce9742135283399a980e18e45e476',
-                            owners: '0x00000000000100000000000000000000000100000001cbd89331d4bb08f7dfbce9742135283399a980e15df8cf45',
-                            signers: [['KaqcqRi56CqJruyEJHDooyo6SzA38Fegf']]
-                        }
-                    },
-                })
-            }
-        })
+        // cy.intercept('POST', '**/ext/bc/P', (request) => {
+        //     if (request.body.method == 'platform.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: {
+        //                     'encoding': 'hex',
+        //                     'endIndex': {
+        //                         'address': 'P-kopernikus1e0vfxvw5hvy00haua96zzdfgxwv6nq8ptng5h7',
+        //                         'utxo': 'Uex3zijzgoXR2D6d8YyLF6Tc3xJcJdD6JxYRpHH3zhf8t9jYy'
+        //                     },
+        //                     'numFetched': '1',
+        //                     'utxos': ['0x0000a47114e8ae68c763c5320ec6d316854769e95f149354b9ac67e999279b64478f000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000070000011f4fe4ab0000000000000000000000000100000001cbd89331d4bb08f7dfbce9742135283399a980e13f46a7ea']
+        //                 }
+        //             },
+        //         })
+        //     } else if (request.body.method == 'platform.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: {
+        //                     'txID': '2FRShpVijngNW1FF12ws7DE43Su7ggUXboTMQtRdGQeZP7U1ZL'
+        //                 }
+        //             },
+        //         })
+        //         request.alias = 'issueTx'
+        //     } else if (request.body.method == 'platform.getTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: {
+        //                     'status': 'Committed'
+        //                 }
+        //             },
+        //         })
+        //     } else if (request.body.method == 'platform.spend') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             body: {
+        //                 id: request.body.id,
+        //                 jsonrpc: '2.0',
+        //                 result: {
+        //                     ins: '0x000000000001ee9167f3ba0d85ed4584d8ed157ea1672836c8026703f4912141cd0166cfaaf5000000005e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000050000011f4ff3ed4000000001000000009d632f28',
+        //                     outs: '0x0000000000015e21ded8a9e53a62f6c48ef045b37c938c5c5e9b25a14b4987db93682ca30f76000000070000011f4fe4ab0000000000000000000000000100000001cbd89331d4bb08f7dfbce9742135283399a980e18e45e476',
+        //                     owners: '0x00000000000100000000000000000000000100000001cbd89331d4bb08f7dfbce9742135283399a980e15df8cf45',
+        //                     signers: [['KaqcqRi56CqJruyEJHDooyo6SzA38Fegf']]
+        //                 }
+        //             },
+        //         })
+        //     }
+        // })
 
-        cy.get('[data-cy="wallet_transfer"]', { timeout: 15000 })
-            .click()
-            .should('have.class', 'router-link-active')
+        // cy.get('[data-cy="wallet_transfer"]', { timeout: 15000 })
+        //     .click()
+        //     .should('have.class', 'router-link-active')
 
-        // Hidden Show Breakdown
-        cy.get('.breakdown_toggle').first().click()
+        // // Hidden Show Breakdown
+        // cy.get('.breakdown_toggle').first().click()
 
-        // Get Own P-Chain Balance
-        cy.get('.alt_breakdown > :nth-child(1) > :nth-child(4)')
-            .invoke('text')
-            .then((balance) => {
-                cy.wrap(balance.replace(/\sCAM/g, '')).as('ownChainBalance')
-            })
+        // // Get Own P-Chain Balance
+        // cy.get('.alt_breakdown > :nth-child(1) > :nth-child(4)')
+        //     .invoke('text')
+        //     .then((balance) => {
+        //         cy.wrap(balance.replace(/\sCAM/g, '')).as('ownChainBalance')
+        //     })
 
-        // Switch Source Chain to P
-        cy.get('.lists > div:nth-child(1) > .chain_select').contains('P').click()
+        // // Switch Source Chain to P
+        // cy.get('.lists > div:nth-child(1) > .chain_select').contains('P').click()
 
-        // Input More than Own Amount
-        cy.get('.bigIn').eq(1).as('inputAmount')
-        cy.get<string>('@ownChainBalance').then((balance) => {
-            const increaseBalance = parseFloat('0.001')
-            cy.get('@inputAmount').type(`${increaseBalance}{enter}`, { force: true })
-            cy.contains('Token').click({ force: true })
-            cy.get('@inputAmount').then((input) => {
-                const amount = parseFloat(input.val() as string)
-                expect(amount).to.lte(parseFloat(balance))
-            })
-        })
+        // // Input More than Own Amount
+        // cy.get('.bigIn').eq(1).as('inputAmount')
+        // cy.get<string>('@ownChainBalance').then((balance) => {
+        //     const increaseBalance = parseFloat('0.001')
+        //     cy.get('@inputAmount').type(`${increaseBalance}{enter}`, { force: true })
+        //     cy.contains('Token').click({ force: true })
+        //     cy.get('@inputAmount').then((input) => {
+        //         const amount = parseFloat(input.val() as string)
+        //         expect(amount).to.lte(parseFloat(balance))
+        //     })
+        // })
     })
 
-    it('verify send tx result from P to P', () => {
+    it.skip('verify send tx result from P to P', () => {
         cy.get<string>('@ownChainBalance').then((balance) => {
             // Input P Chain Addr
             cy.get('.bottom_tabs > .chain_select > button:nth-child(2)').click()

--- a/cypress/e2e/send/send_x-chain_mock.cy.ts
+++ b/cypress/e2e/send/send_x-chain_mock.cy.ts
@@ -4,68 +4,68 @@ import { BN, bnToBigAvaxX } from '@c4tplatform/camino-wallet-sdk/dist'
 describe('Send transaction with x-chain balance', () => {
     beforeEach(() => {
 
-        // access wallet with private key
-        cy.loginWalletWith('privateKey', 'walletHasXBalance')
+        // // access wallet with private key
+        // cy.loginWalletWith('privateKey', 'walletHasXBalance')
 
-        // mock avm.**
-        cy.intercept('POST', '**/ext/bc/X', (request) => {
-            if (request.body.method == 'avm.getUTXOs') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/send_avm_getUTXOs.json'
-                })
-            }
-            else if (request.body.method == 'avm.issueTx') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_issueTx.json'
-                })
-                request.alias = 'issueTx'
-            }
-            else if (request.body.method == 'avm.getTxStatus') {
-                request.reply({
-                    statusCode: 200,
-                    fixture: 'mocks/avm_getTxStatus.json'
-                })
-                request.alias = 'getTxStatus'
-            }
-            else {
-                console.log('Other query in X Chain', request.body.method)
-            }
-        })
+        // // mock avm.**
+        // cy.intercept('POST', '**/ext/bc/X', (request) => {
+        //     if (request.body.method == 'avm.getUTXOs') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/send_avm_getUTXOs.json'
+        //         })
+        //     }
+        //     else if (request.body.method == 'avm.issueTx') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_issueTx.json'
+        //         })
+        //         request.alias = 'issueTx'
+        //     }
+        //     else if (request.body.method == 'avm.getTxStatus') {
+        //         request.reply({
+        //             statusCode: 200,
+        //             fixture: 'mocks/avm_getTxStatus.json'
+        //         })
+        //         request.alias = 'getTxStatus'
+        //     }
+        //     else {
+        //         console.log('Other query in X Chain', request.body.method)
+        //     }
+        // })
 
-        // click Send tab
-        cy.get('[data-cy="wallet_transfer"]').click()
+        // // click Send tab
+        // cy.get('[data-cy="wallet_transfer"]').click()
 
-        cy.get('.lists > div:nth-child(1) > .chain_select').contains('X').as('btnSourceX')
+        // cy.get('.lists > div:nth-child(1) > .chain_select').contains('X').as('btnSourceX')
 
-        cy.get('div.header > button:nth-child(3)').as('btnBreakdown')
+        // cy.get('div.header > button:nth-child(3)').as('btnBreakdown')
 
-        cy.get('div.alt_info > div > div:nth-child(1) > p:nth-child(2)').as('textXAvailBalance')
+        // cy.get('div.alt_info > div > div:nth-child(1) > p:nth-child(2)').as('textXAvailBalance')
 
-        cy.get('div.max_in_cont.hover_border > div > input').as('inputAmount')
+        // cy.get('div.max_in_cont.hover_border > div > input').as('inputAmount')
 
-        cy.get('div > div.col_balance > p').as('textMaxBalance')
+        // cy.get('div > div.col_balance > p').as('textMaxBalance')
 
-        cy.get('div.bottom_tabs > div > button:nth-child(1)').as('btnXChain')
+        // cy.get('div.bottom_tabs > div > button:nth-child(1)').as('btnXChain')
 
-        cy.get('div.bottom > div.bottom_rest > p.addr_text').as('textAddress')
+        // cy.get('div.bottom > div.bottom_rest > p.addr_text').as('textAddress')
 
-        cy.get('[data-cy="wallet_address"]').as('textWalletAddress')
+        // cy.get('[data-cy="wallet_address"]').as('textWalletAddress')
 
-        cy.get('div.new_order_Form > div:nth-child(2) > div.to_address > div > input').as(
-            'inputToAddress'
-        )
+        // cy.get('div.new_order_Form > div:nth-child(2) > div.to_address > div > input').as(
+        //     'inputToAddress'
+        // )
 
-        cy.get('div.new_order_Form > div:nth-child(2) > div.checkout > button').as('btnConfirm')
+        // cy.get('div.new_order_Form > div:nth-child(2) > div.checkout > button').as('btnConfirm')
 
-        cy.get('div.checkout > button:eq(0)').as('btnSend')
+        // cy.get('div.checkout > button:eq(0)').as('btnSend')
 
         // cy.intercept('POST', '**/ext/bc/X').as('xEndpoints')
 
     })
 
-    it('Send transaction with all available x-chain balance', () => {
+    it.skip('Send transaction with all available x-chain balance', () => {
 
         // click Source Chain X
         cy.get('@btnSourceX').click()

--- a/cypress/e2e/wallet_activity_transactions.cy.ts
+++ b/cypress/e2e/wallet_activity_transactions.cy.ts
@@ -141,7 +141,7 @@ describe('Activity Transactions', () => {
         cy.visit('/')
     })
 
-    it('access activity transactions', () => {
+    it.skip('access activity transactions', () => {
         addKopernikusNetwork(cy)
         //changeNetwork(cy);
 

--- a/cypress/e2e/wallet_add_erc20.cy.ts
+++ b/cypress/e2e/wallet_add_erc20.cy.ts
@@ -16,7 +16,7 @@ describe('Add ERC20 Token', () => {
     before(() => {
         cy.visit('/')
     })
-    it('has access/add erc20', async () => {
+    it.skip('has access/add erc20', async () => {
         addKopernikusNetwork(cy)
         //changeNetwork(cy);
         accessWallet(cy, 'mnemonic')

--- a/cypress/e2e/wallet_balance.cy.ts
+++ b/cypress/e2e/wallet_balance.cy.ts
@@ -7,7 +7,7 @@ describe('Wallet Balance Mnemonic', () => {
         cy.visit('/')
     })
 
-    it('wallet balance', () => {
+    it.skip('wallet balance', () => {
         changeNetwork(cy)
         accessWallet(cy, 'mnemonic')
         interceptXChainBalance()

--- a/cypress/e2e/wallet_manage_keys.cy.ts
+++ b/cypress/e2e/wallet_manage_keys.cy.ts
@@ -11,7 +11,7 @@ describe('Wallet Manage Keys', () => {
         cy.visit('/')
     })
 
-    it('wallet manage keys', () => {
+    it.skip('wallet manage keys', () => {
         //changeNetwork(cy)
         addKopernikusNetwork(cy)
 


### PR DESCRIPTION
In this PR, cypress tests are disabled from the camino-wallet repository.
This is because the cypress tests that are updated are those from the camino-suite repository, so these tests that are in camino-wallet become obsolete.