### PR TITLE
fix(kyb): six styling and change wording

### DIFF
--- a/src/components/modals/KybModal.vue
+++ b/src/components/modals/KybModal.vue
@@ -1,6 +1,7 @@
 <template>
     <div>
         <Modal
+            :isKybModal="true"
             ref="modal"
             :title="$t('kyc_process.title-kyb')"
             class="modal_main"
@@ -43,7 +44,7 @@
                             type="submit"
                             :disabled="submitUserDataDisabled"
                             :loading="isLoading"
-                            class="button_submit_form"
+                            class="button_submit_form submit"
                         >
                             {{ $t('kyc_process.submit') }}
                         </v-btn>
@@ -225,7 +226,9 @@ export default class KybModal extends Vue {
             transform: translate(-50%, -50%);
         }
     }
-
+    .submit {
+        justify-self: end;
+    }
     .modal_bg {
         width: 100vw !important;
         position: fixed;

--- a/src/components/modals/Modal.vue
+++ b/src/components/modals/Modal.vue
@@ -34,6 +34,7 @@ export default class Modal extends Vue {
     @Prop({ default: '' }) subtitle!: string
     @Prop({ default: true }) can_close!: boolean
     @Prop({ default: false }) icy!: boolean
+    @Prop() isKybModal?: boolean
 
     isActive: boolean = false
 
@@ -47,7 +48,7 @@ export default class Modal extends Vue {
     }
 
     bgclick() {
-        if (this.can_close) {
+        if (!this.isKybModal && this.can_close) {
             this.close()
         }
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -229,7 +229,7 @@
         "link_to_documentation": "read our documentation.",
         "info_explanation_p1": "We need your email address and phone number to follow up with you in case your verification requires clarification and to inform you about the verification result.",
         "info_explanation_p2": "Please enter your contact details below.",
-        "info_explanation_kyb_p1": "Verifying your wallet will allow you or your company to be a more active player in the Camino network, such as interacting with specific dApps and participating in governance, for more information on what the verification enables please",
+        "info_explanation_kyb_p1": "Verifying your wallet will allow you or your company to be a more trusted contributor in the Camino network, such as interacting with specific dApps and participating in governance, for more information on what the verification enables please",
         "info_explanation_kyb_p2": "We need your email address and phone number to follow up with you in case your verification requires clarification and to inform you about the verification result"
     },
     "studio": {


### PR DESCRIPTION
- Change “to be a more active player” into “to be a more trusted contributor”
- Move the submit button on the right 
- If the user clicks outside of the modal it closes, change it to make the KYB Process model fixed so that it is not possible for it to be closed unless the person clicks the “X' button. 