### PR TITLE
Edit msig fixes

### DIFF
--- a/src/views/EditMultisigWallet.vue
+++ b/src/views/EditMultisigWallet.vue
@@ -280,6 +280,7 @@ export default class EditMultisigWallet extends Vue {
 
     @Watch('activeWallet')
     @Watch('activeNetwork')
+    @Watch('pendingSendMultisigTX')
     async getAliasInfos() {
         this.mode = 'VIEW'
 

--- a/src/views/EditMultisigWallet.vue
+++ b/src/views/EditMultisigWallet.vue
@@ -312,6 +312,7 @@ export default class EditMultisigWallet extends Vue {
                 })
         } else {
             const msigAlias = this.activeWallet?.getStaticAddress('P')
+            if (!msigAlias) return
             const msigData = await ava.PChain().getMultisigAlias(msigAlias)
 
             this.multisigName = Buffer.from(msigData.memo.replace('0x', ''), 'hex').toString()


### PR DESCRIPTION
This PR addresses two key issues:

- Ensures multi-sig data is refreshed upon detecting a pending transaction, now sourcing the information directly from the unsigned transaction.

- Properly handles scenarios where msigAlias is undefined, typically encountered during logouts.