### PR TITLE
fix: pass initial addresses & threshold in the edit msig tx

### DIFF
--- a/src/helpers/wallet_helper.ts
+++ b/src/helpers/wallet_helper.ts
@@ -756,8 +756,10 @@ class WalletHelper {
 
     static async sendMultisigAliasTxUpdate(
         wallet: WalletType,
+        initialAddresses: string[],
         addresses: string[],
         memo: string,
+        initialThreshold: number,
         threshold: number,
         multisigAliasAddress: string
     ) {
@@ -778,12 +780,12 @@ class WalletHelper {
             .PChain()
             .buildMultisigAliasTx(
                 wallet.platformUtxoset,
-                [[multisigAliasAddress], addresses],
+                [[multisigAliasAddress], initialAddresses],
                 [multisigAliasAddress],
                 multisigAliasParams,
                 undefined,
                 ZeroBN,
-                threshold
+                initialThreshold
             )
 
         let tx = await wallet.signP(unsignedTx)


### PR DESCRIPTION
**Summary:**
This PR addresses an issue where the initial set of addresses and threshold values were not being passed correctly during the edit multi-signature transaction process.

**Changes:**
- Modified the `saveEditMsig` method to include the initial addresses and threshold in the transaction parameters when editing a msig tx.
- Refactored the error handling logic to make the code more maintainable and easier to read.
- Introduced a default parameter in getNonEmptyAddresses to prevent potential errors when the addresses parameter is undefined.