### PR TITLE
feat: creating deposit Offers

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
         "weekstart": "1.0.1"
     },
     "dependencies": {
-        "@c4tplatform/signavaultjs": "^1.0.11",
+        "@c4tplatform/signavaultjs": "^1.1",
         "@cypress/xpath": "^2.0.3",
         "vue": "^2.6.11",
         "vue-cli-plugin-vuetify": "^2.0.3",

--- a/src/components/CamInput.vue
+++ b/src/components/CamInput.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
 @Component
 export default class CamInput extends Vue {
@@ -44,7 +44,7 @@ export default class CamInput extends Vue {
 }
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .cam-input {
     display: flex;
     flex-direction: column;

--- a/src/components/misc/AvaxInput.vue
+++ b/src/components/misc/AvaxInput.vue
@@ -1,32 +1,53 @@
 <template>
-    <div class="avax_input">
-        <div
-            :class="
-                'col1'.concat(readonly ? '' : ' hover_border').concat(camInput ? ' cam-input' : '')
-            "
-        >
-            <button class="max_but" @click="maxOut" v-if="max">MAX</button>
-            <BigNumInput
-                ref="amt_in"
-                class="amt_in"
-                contenteditable="amt_in"
-                :denomination="9"
-                :max="max"
-                placeholder="0.00"
-                @change="amount_in"
-                :readonly="readonly"
-                :initial="initial"
-            ></BigNumInput>
-        </div>
-        <p :class="'ticker'.concat(camInput ? ' cam-input' : '')">{{ nativeAssetSymbol }}</p>
-        <div v-if="balance" class="balance">
-            <div>
-                <p>
-                    <b>{{ $t('misc.balance') }}:</b>
-                    {{ balanceBig }}
-                </p>
+    <div class="avax_input__container">
+        <div class="avax_input">
+            <div
+                :class="
+                    'col1'
+                        .concat(readonly ? '' : ' hover_border')
+                        .concat(camInput ? ' cam-input' : '')
+                "
+            >
+                <button class="max_but" @click="maxOut" v-if="max">MAX</button>
+                <BigNumInput
+                    ref="amt_in"
+                    class="amt_in"
+                    contenteditable="amt_in"
+                    :denomination="9"
+                    :max="max"
+                    placeholder="0.00"
+                    @change="amount_in"
+                    :readonly="readonly"
+                    :initial="initial"
+                ></BigNumInput>
             </div>
-            <div></div>
+            <p :class="'ticker'.concat(camInput ? ' cam-input' : '')">{{ nativeAssetSymbol }}</p>
+            <div v-if="balance" class="balance">
+                <div>
+                    <p>
+                        <b>{{ $t('misc.balance') }}:</b>
+                        {{ balanceBig }}
+                    </p>
+                </div>
+                <div></div>
+            </div>
+        </div>
+        <div class="validation-message" v-if="error && errorMessage">
+            <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path
+                    d="M10.8333 10.8333H9.16666V5.83332H10.8333M10.8333 14.1667H9.16666V12.5H10.8333M9.99999 1.66666C8.90564 1.66666 7.82201 1.8822 6.81096 2.30099C5.79991 2.71978 4.88125 3.33361 4.10743 4.10743C2.54463 5.67024 1.66666 7.78985 1.66666 9.99999C1.66666 12.2101 2.54463 14.3297 4.10743 15.8925C4.88125 16.6664 5.79991 17.2802 6.81096 17.699C7.82201 18.1178 8.90564 18.3333 9.99999 18.3333C12.2101 18.3333 14.3297 17.4553 15.8925 15.8925C17.4553 14.3297 18.3333 12.2101 18.3333 9.99999C18.3333 8.90564 18.1178 7.82201 17.699 6.81096C17.2802 5.79991 16.6664 4.88125 15.8925 4.10743C15.1187 3.33361 14.2001 2.71978 13.189 2.30099C12.178 1.8822 11.0943 1.66666 9.99999 1.66666Z"
+                    fill="#E5431F"
+                />
+            </svg>
+            <p class="err">
+                {{ errorMessage }}
+            </p>
         </div>
     </div>
 </template>
@@ -56,6 +77,8 @@ export default class AvaxInput extends Vue {
     @Prop() alias?: string
     @Prop() readonly?: boolean
     @Prop() camInput?: boolean
+    @Prop({ default: false }) error!: boolean
+    @Prop({ default: '' }) errorMessage!: string
 
     maxOut(ev: MouseEvent) {
         ev?.preventDefault()
@@ -108,6 +131,11 @@ export default class AvaxInput extends Vue {
 @use '../../styles/abstracts/mixins';
 
 .avax_input {
+    &__container {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+    }
     display: grid;
     grid-template-columns: 1fr max-content;
     grid-gap: 0px 10px;
@@ -183,7 +211,6 @@ export default class AvaxInput extends Vue {
     input,
     p {
         background-color: transparent !important;
-        text-align: left;
     }
 }
 .ticker {
@@ -196,6 +223,20 @@ export default class AvaxInput extends Vue {
     opacity: 0.4;
     &:hover {
         opacity: 1;
+    }
+}
+
+.validation-message {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    p {
+        color: var(--camino-brand-error, #e5431f);
+        font-family: Inter;
+        font-size: 14px;
+        font-style: normal;
+        font-weight: 400;
+        line-height: 20px;
     }
 }
 

--- a/src/components/misc/AvaxInput.vue
+++ b/src/components/misc/AvaxInput.vue
@@ -1,6 +1,10 @@
 <template>
     <div class="avax_input">
-        <div class="col1 hover_border">
+        <div
+            :class="
+                'col1'.concat(readonly ? '' : ' hover_border').concat(camInput ? ' cam-input' : '')
+            "
+        >
             <button class="max_but" @click="maxOut" v-if="max">MAX</button>
             <BigNumInput
                 ref="amt_in"
@@ -14,7 +18,7 @@
                 :initial="initial"
             ></BigNumInput>
         </div>
-        <p class="ticker">{{ nativeAssetSymbol }}</p>
+        <p :class="'ticker'.concat(camInput ? ' cam-input' : '')">{{ nativeAssetSymbol }}</p>
         <div v-if="balance" class="balance">
             <div>
                 <p>
@@ -27,12 +31,12 @@
     </div>
 </template>
 <script lang="ts">
+import { Big } from '@/helpers/helper'
 import 'reflect-metadata'
-import { Vue, Component, Prop, Model } from 'vue-property-decorator'
-import { bnToBig, Big } from '@/helpers/helper'
+import { Component, Model, Prop, Vue } from 'vue-property-decorator'
 //@ts-ignore
-import { BigNumInput } from '@c4tplatform/vue_components'
 import { BN } from '@c4tplatform/caminojs/dist'
+import { BigNumInput } from '@c4tplatform/vue_components'
 import { priceDict } from '../../store/types'
 
 @Component({
@@ -51,6 +55,7 @@ export default class AvaxInput extends Vue {
     @Prop() balance?: Big | null
     @Prop() alias?: string
     @Prop() readonly?: boolean
+    @Prop() camInput?: boolean
 
     maxOut(ev: MouseEvent) {
         ev?.preventDefault()
@@ -108,11 +113,10 @@ export default class AvaxInput extends Vue {
     grid-gap: 0px 10px;
     color: var(--primary-color);
     width: 100%;
-    height: 40px;
 
     .amt_in {
         color: var(--primary-color);
-        font-size: 15px;
+        font-size: 14px;
         font-family: 'Inter';
         flex-grow: 1;
         flex-shrink: 1;
@@ -120,6 +124,7 @@ export default class AvaxInput extends Vue {
         box-sizing: content-box;
         outline: none !important;
         border: none !important;
+        /* text-align: left !important; */
         &[readonly] {
             color: var(--primary-color-light);
             cursor: pointer;
@@ -130,7 +135,6 @@ export default class AvaxInput extends Vue {
     .amt_in,
     .max_but {
         background-color: var(--bg-light);
-        //border-radius: 3px;
     }
 }
 
@@ -168,18 +172,25 @@ export default class AvaxInput extends Vue {
     grid-template-columns: max-content 1fr;
     width: 100%;
     box-sizing: border-box;
-    padding: 8px 14px;
+    padding: 10px 12px;
     position: relative;
 }
 
+.cam-input {
+    background-color: transparent !important;
+    border-radius: 8px;
+    border: 1px solid var(--camino-slate-slate-600);
+    input,
+    p {
+        background-color: transparent !important;
+        text-align: left;
+    }
+}
 .ticker {
     border-radius: var(--border-radius-sm);
-    padding: 8px 14px;
+    padding: 10px 12px;
 }
 
-p {
-    text-align: center;
-}
 .max_but {
     font-size: 13px;
     opacity: 0.4;

--- a/src/components/modals/ClaimRewardModal.vue
+++ b/src/components/modals/ClaimRewardModal.vue
@@ -108,7 +108,12 @@ export default class ModalClaimReward extends Vue {
     get nativeAssetSymbol(): string {
         return this.ava_asset?.symbol ?? ''
     }
-
+    async updateRewards() {
+        await this.$store.dispatch('Assets/updateUTXOs')
+        await this.$store.dispatch('History/updateTransactionHistory')
+        await this.$store.dispatch('Platform/updateAllDepositOffers')
+        await this.$store.dispatch('Platform/updateRewards')
+    }
     async confirmClaim() {
         const wallet: WalletType = this.$store.state.activeWallet
         const hrp = ava.getHRP()
@@ -132,6 +137,7 @@ export default class ModalClaimReward extends Vue {
                 msgTitle: 'Transaction',
                 msgText: `Claim Successful (TX: ${result})`,
             })
+            this.updateRewards()
         } catch (error) {
             if (error instanceof SignatureError) {
                 this.$store.dispatch('updateTransaction', {
@@ -142,11 +148,6 @@ export default class ModalClaimReward extends Vue {
                 })
             } else {
                 console.error(error)
-                this.$store.dispatch('Notifications/add', {
-                    type: 'error',
-                    title: 'Claim Failed',
-                    message: error,
-                })
                 this.claimed = false
                 return
             }

--- a/src/components/modals/ClaimRewardModal.vue
+++ b/src/components/modals/ClaimRewardModal.vue
@@ -1,0 +1,188 @@
+<template>
+    <modal ref="modal" title="Claim Reward" @beforeClose="beforeClose">
+        <div class="claim-reward-modal">
+            <div v-if="!claimed">
+                <div>
+                    <AvaxInput :max="amount" :initial="amount" v-model="amt"></AvaxInput>
+                    <br />
+                    <p class="text-modal">
+                        {{
+                            $t('earn.rewards.claim_modal.note_message', {
+                                fee: feeAmt,
+                                symbol: nativeAssetSymbol,
+                            })
+                        }}
+                    </p>
+                </div>
+                <div class="modal-buttons">
+                    <v-btn depressed class="button_secondary btn-claim" @click="confirmClaim()">
+                        {{ $t('earn.rewards.claim_modal.confirm') }}
+                    </v-btn>
+                    <v-btn depressed class="button_primary" @click="close()">
+                        {{ $t('earn.rewards.claim_modal.cancel') }}
+                    </v-btn>
+                </div>
+            </div>
+            <div class="confirmed-claimed" v-else>
+                <br />
+                <h2>
+                    {{
+                        $t('earn.rewards.claim_modal.confirmation_message', {
+                            amount: confirmedClaimedAmount,
+                            symbol: nativeAssetSymbol,
+                        })
+                    }}
+                </h2>
+                <br />
+            </div>
+        </div>
+    </modal>
+</template>
+<script lang="ts">
+import Big from 'big.js'
+import 'reflect-metadata'
+import { Component, Prop, Vue } from 'vue-property-decorator'
+
+import { ava, bintools } from '@/AVA'
+import AvaxInput from '@/components/misc/AvaxInput.vue'
+import { WalletHelper } from '@/helpers/wallet_helper'
+import AvaAsset from '@/js/AvaAsset'
+import { WalletType } from '@/js/wallets/types'
+import { RewardOwner } from '@/store/modules/platform/types'
+import Modal from './Modal.vue'
+
+import { BN } from '@c4tplatform/caminojs/dist'
+import { OutputOwners, SignatureError } from '@c4tplatform/caminojs/dist/common'
+import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
+
+@Component({
+    components: {
+        AvaxInput,
+        Modal,
+    },
+})
+export default class ModalClaimReward extends Vue {
+    @Prop() depositTxID?: string
+    @Prop() amount!: BN
+    @Prop() rewardOwner!: RewardOwner
+    @Prop() validatorClaim!: boolean
+
+    claimed: boolean = false
+    confirmedClaimedAmount: string = ''
+    amt: BN = this.amount
+
+    $refs!: {
+        modal: Modal
+    }
+    open() {
+        this.$refs.modal.open()
+    }
+    close() {
+        this.$refs.modal.close()
+    }
+
+    beforeClose() {
+        this.confirmedClaimedAmount = ''
+        this.$emit('beforeCloseModal', this.claimed)
+        this.claimed = false
+    }
+
+    formattedAmount(val: BN): string {
+        let big = Big(val.toString()).div(Big(ONEAVAX.toString()))
+        return big.toLocaleString()
+    }
+
+    get feeAmt(): string {
+        return this.formattedAmount(ava.PChain().getTxFee())
+    }
+
+    get claimableAmount(): string {
+        return this.formattedAmount(this.amount)
+    }
+
+    get ava_asset(): AvaAsset | null {
+        let ava = this.$store.getters['Assets/AssetAVA']
+        return ava
+    }
+
+    get nativeAssetSymbol(): string {
+        return this.ava_asset?.symbol ?? ''
+    }
+
+    async confirmClaim() {
+        const wallet: WalletType = this.$store.state.activeWallet
+        const hrp = ava.getHRP()
+        const rewardOwner = new OutputOwners(
+            this.rewardOwner.addresses.map((a) => bintools.stringToAddress(a, hrp)),
+            this.rewardOwner.locktime,
+            this.rewardOwner.threshold
+        )
+
+        try {
+            const result = await WalletHelper.buildDepositClaimTx(
+                wallet,
+                this.depositTxID,
+                rewardOwner,
+                this.amt,
+                this.validatorClaim
+            )
+            this.$store.dispatch('updateTransaction', {
+                withDeposit: true,
+                msgType: 'success',
+                msgTitle: 'Transaction',
+                msgText: `Claim Successful (TX: ${result})`,
+            })
+        } catch (error) {
+            if (error instanceof SignatureError) {
+                this.$store.dispatch('updateTransaction', {
+                    onlyMultisig: true,
+                    msgType: 'success',
+                    msgTitle: 'Multisignature',
+                    msgText: 'Transaction Recorded.',
+                })
+            } else {
+                console.error(error)
+                this.$store.dispatch('Notifications/add', {
+                    type: 'error',
+                    title: 'Claim Failed',
+                    message: error,
+                })
+                this.claimed = false
+                return
+            }
+        }
+        this.confirmedClaimedAmount = this.formattedAmount(this.amt)
+        this.claimed = true
+    }
+}
+</script>
+<style scoped lang="scss">
+.claim-reward-modal {
+    padding: 30px 22px;
+    text-align: center;
+    width: 600px;
+    overflow-x: hidden;
+}
+
+.modal-buttons {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+    gap: 10px;
+}
+
+.text-modal {
+    color: var(--warning);
+}
+
+@media screen and (max-width: 720px) {
+    .claim-reward-modal {
+        width: 350px;
+    }
+}
+@media screen and (min-width: 720px) and (max-width: 1440px) {
+    .claim-reward-modal {
+        width: 475px;
+    }
+}
+</style>

--- a/src/components/wallet/earn/ClaimableRewardCard.vue
+++ b/src/components/wallet/earn/ClaimableRewardCard.vue
@@ -1,0 +1,114 @@
+<template>
+    <div class="claim_row">
+        <h3>{{ title }}</h3>
+        <div class="claim_amount">
+            <label>{{ $t('earn.rewards.active_earning.pending_reward') }}:</label>
+            <p class="reward">{{ cleanAvaxBN(reward.amountToClaim) }} {{ nativeAssetSymbol }}</p>
+        </div>
+        <div class="claim_button_container">
+            <button
+                class="claim_button button_primary"
+                @click="openModal"
+                :disabled="!isClaimDisabled"
+            >
+                {{ $t('earn.rewards.active_earning.claim') }}
+            </button>
+        </div>
+        <ModalClaimReward
+            ref="modal_claim_reward"
+            :amount="reward.amountToClaim"
+            :rewardOwner="reward.rewardOwner"
+        />
+    </div>
+</template>
+<script lang="ts">
+import 'reflect-metadata'
+import { Component, Prop, Vue } from 'vue-property-decorator'
+
+import ModalClaimReward from '@/components/modals/ClaimRewardModal.vue'
+import { cleanAvaxBN } from '@/helpers/helper'
+import { PlatformRewardTreasury } from '@/store/modules/platform/types'
+
+import { BN } from '@c4tplatform/caminojs/dist'
+
+@Component({
+    components: {
+        ModalClaimReward,
+    },
+})
+export default class ClaimableRewardCard extends Vue {
+    now: number = Date.now()
+    intervalID: any = null
+    claimDisabled: boolean = true
+
+    @Prop() reward!: PlatformRewardTreasury
+
+    $refs!: {
+        modal_claim_reward: ModalClaimReward
+    }
+
+    get nativeAssetSymbol(): string {
+        const asset = this.$store.getters['Assets/AssetAVA']
+        return asset?.symbol ?? ''
+    }
+
+    get isClaimDisabled() {
+        return !this.reward.amountToClaim.isZero()
+    }
+
+    get title() {
+        return this.reward.type === 'validator' ? 'Validator Reward' : 'Deposit Reward'
+    }
+
+    cleanAvaxBN(val: BN): string {
+        return cleanAvaxBN(val)
+    }
+
+    openModal() {
+        this.$refs.modal_claim_reward.open()
+    }
+}
+</script>
+<style scoped lang="scss">
+@use '../../../styles/abstracts/mixins';
+
+.claim_row {
+    display: flex;
+    justify-content: space-between;
+    border-radius: var(--border-radius-sm);
+    overflow: hidden;
+    font-size: 14px;
+    background-color: var(--bg-light);
+    padding: 1rem;
+    > h3 {
+        margin-bottom: 1em;
+    }
+    > div {
+        display: flex;
+    }
+}
+
+.claim_amount {
+    label {
+        color: var(--primary-color-light) !important;
+    }
+    flex-direction: column;
+}
+
+.claim_button {
+    border-radius: var(--border-radius-sm);
+    padding: 8px 30px;
+    height: max-content;
+    align-self: flex-end;
+    margin-left: auto;
+    &[disabled] {
+        background-color: var(--primary-color) !important;
+    }
+}
+
+@include mixins.mobile-device {
+    .claim_row {
+        flex-direction: column;
+    }
+}
+</style>

--- a/src/components/wallet/earn/CreateOfferForm.vue
+++ b/src/components/wallet/earn/CreateOfferForm.vue
@@ -1,0 +1,876 @@
+<template>
+    <div>
+        <form class="form__container">
+            <div class="form__container" v-if="!pendingSendMultisigTX">
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.memo').toString() }}
+                    </label>
+                    <CamInput
+                        class="form__container__element__input"
+                        :placeholder="`Memo`"
+                        v-model="offer.memo"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.offer_start') }}
+                    </label>
+                    <DateForm
+                        class="form__container__element__date-picker"
+                        :minDurationMs="minDuration"
+                        :maxDurationMs="maxDuration"
+                        :defaultDurationMs="defaultDuration"
+                        @change_end="setStartDate"
+                    ></DateForm>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.offer_end') }}
+                    </label>
+                    <DateForm
+                        class="form__container__element__date-picker"
+                        :minDurationMs="minDuration"
+                        :maxDurationMs="maxDuration"
+                        :defaultDurationMs="maxDuration"
+                        @change_end="setEndDate"
+                    ></DateForm>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.min_amount') }}
+                    </label>
+                    <AvaxInput
+                        v-model="offer.minAmount"
+                        :initial="offer.minAmount"
+                        :camInput="true"
+                    ></AvaxInput>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.total_max_amount') }}
+                    </label>
+                    <AvaxInput v-model="offer.totalMaxAmount" :camInput="true"></AvaxInput>
+                </div>
+
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.min_duration') }}
+                    </label>
+                    <CamInput
+                        class="form__container__element__input"
+                        :placeholder="`minDuration`"
+                        v-model.number="offer.minDuration"
+                    />
+                    <!-- <input
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="offer.minDuration"
+                        inputmode="numeric"
+                    /> -->
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.max_duration') }}
+                    </label>
+                    <CamInput
+                        class="form__container__element__input"
+                        :placeholder="`maxDuration`"
+                        v-model.number="offer.maxDuration"
+                    />
+                    <!-- <input
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="offer.maxDuration"
+                        inputmode="numeric"
+                    /> -->
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.unlock_duration') }}
+                    </label>
+                    <CamInput
+                        class="form__container__element__input"
+                        :placeholder="`unlockPeriodDuration`"
+                        v-model.number="offer.unlockPeriodDuration"
+                    />
+                    <!-- <input
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="offer.unlockPeriodDuration"
+                        inputmode="numeric"
+                    /> -->
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.interrest_rate') }}
+                    </label>
+                    <input
+                        class="form__container__element__input"
+                        type="number"
+                        :value="offer.interestRateNominator.toString(10)"
+                        v-on:input="setInterestRate"
+                        min="0"
+                        inputmode="numeric"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.no_rewards_duration') }}
+                    </label>
+                    <CamInput
+                        class="form__container__element__input"
+                        :placeholder="`noRewardsPeriodDuration`"
+                        v-model.number="offer.noRewardsPeriodDuration"
+                    />
+                    <!-- <input
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="offer.noRewardsPeriodDuration"
+                        inputmode="numeric"
+                    /> -->
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.total_max_reward_amount') }}
+                    </label>
+                    <AvaxInput
+                        v-model="offer.totalMaxRewardAmount"
+                        :readonly="sunrisePhase === 0"
+                        :camInput="true"
+                    ></AvaxInput>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.flags') }}
+                    </label>
+                    <input
+                        class="form__container__element__input"
+                        type="number"
+                        :value="offer.flags.toString(10)"
+                        v-on:input="setFlags"
+                        min="0"
+                        inputmode="numeric"
+                    />
+                </div>
+
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.owner_address') }}
+                    </label>
+                    <CamInput
+                        class="form__container__element__input"
+                        :placeholder="`ownerAddress`"
+                        v-model.number="offer.ownerAddress"
+                        :disabled="sunrisePhase === 0"
+                    />
+                    <!-- <input
+                        class="form__container__element__input"
+                        type="text"
+                        v-model="offer.ownerAddress"
+                        :disabled="sunrisePhase === 0"
+                    /> -->
+                </div>
+
+                <div v-if="!isMultisigWallet" class="form__container__element">
+                    <label class="form__container__element__label" style="margin-bottom: 8px">
+                        Addresses allowed to deposit
+                    </label>
+                    <div
+                        v-for="(address, index) in addresses"
+                        :key="index"
+                        class="form__container__element__addresses"
+                    >
+                        <!-- <div class="circle number">{{ index + 1 }}</div> -->
+                        <input
+                            class="form__container__element__input"
+                            v-model="address.address"
+                            style="margin-bottom: 8px"
+                        />
+                    </div>
+                    <div class="form__container__element__new-addresses">
+                        <button @click.prevent="addAddress" class="circle plus-button">
+                            <fa icon="plus"></fa>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="form__container" v-else-if="pendingOffer">
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.memo').toString() }}
+                    </label>
+                    <input
+                        class="form__container__element__input"
+                        placeholder="Memo"
+                        v-model="pendingOffer.memo"
+                        :disabled="true"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.offer_start') }}
+                    </label>
+                    <DateForm
+                        class="form__container__element__date-picker"
+                        :minDurationMs="minDuration"
+                        :maxDurationMs="maxDuration"
+                        :defaultDurationMs="defaultDuration"
+                        @change_end="setStartDate"
+                        :pendingTxDate="pendingOffer.start"
+                    ></DateForm>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.offer_end') }}
+                    </label>
+                    <DateForm
+                        class="form__container__element__date-picker"
+                        :minDurationMs="minDuration"
+                        :maxDurationMs="maxDuration"
+                        :defaultDurationMs="maxDuration"
+                        @change_end="setEndDate"
+                        :pendingTxDate="pendingOffer.end"
+                    ></DateForm>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.min_amount') }}
+                    </label>
+                    <AvaxInput
+                        v-model="pendingOffer.minAmount"
+                        :initial="pendingOffer.minAmount"
+                        :readonly="true"
+                        :camInput="true"
+                    ></AvaxInput>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.total_max_amount') }}
+                    </label>
+                    <AvaxInput
+                        v-model="pendingOffer.totalMaxAmount"
+                        :initial="pendingOffer.totalMaxAmount"
+                        :readonly="true"
+                        :camInput="true"
+                    ></AvaxInput>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.min_duration') }}
+                    </label>
+                    <input
+                        :disabled="true"
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="pendingOffer.minDuration"
+                        inputmode="numeric"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.max_duration') }}
+                    </label>
+                    <input
+                        :disabled="true"
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="pendingOffer.maxDuration"
+                        inputmode="numeric"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.unlock_duration') }}
+                    </label>
+                    <input
+                        :disabled="true"
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="pendingOffer.unlockPeriodDuration"
+                        inputmode="numeric"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.interrest_rate') }}
+                    </label>
+                    <input
+                        class="form__container__element__input"
+                        type="number"
+                        :value="pendingOffer.interestRateNominator"
+                        v-on:input="setInterestRate"
+                        min="0"
+                        inputmode="numeric"
+                        :disabled="true"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.no_rewards_duration') }}
+                    </label>
+                    <input
+                        :disabled="true"
+                        class="form__container__element__input"
+                        type="number"
+                        v-model="pendingOffer.noRewardsPeriodDuration"
+                        inputmode="numeric"
+                    />
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.total_max_reward_amount') }}
+                    </label>
+                    <AvaxInput
+                        v-model="pendingOffer.totalMaxRewardAmount"
+                        :initial="pendingOffer.totalMaxRewardAmount"
+                        :readonly="true"
+                        :camInput="true"
+                    ></AvaxInput>
+                </div>
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.flags') }}
+                    </label>
+                    <input
+                        :disabled="true"
+                        class="form__container__element__input"
+                        type="number"
+                        :value="pendingOffer.flags"
+                        v-on:input="setFlags"
+                        min="0"
+                        inputmode="numeric"
+                    />
+                </div>
+
+                <div class="form__container__element">
+                    <label class="form__container__element__label">
+                        {{ $t('earn.rewards.create.owner_address') }}
+                    </label>
+                    <input
+                        class="form__container__element__input"
+                        type="text"
+                        v-model="pendingOffer.ownerAddress"
+                        :disabled="true"
+                    />
+                </div>
+
+                <div v-if="!isMultisigWallet" class="form__container__element">
+                    <label class="form__container__element__label">
+                        Addresses allowed to deposit
+                    </label>
+                    <div
+                        v-for="(address, index) in addresses"
+                        :key="index"
+                        class="form__container__element__addresses"
+                    >
+                        <!-- <div class="circle number">{{ index + 1 }}</div> -->
+                        <input
+                            :disabled="true"
+                            class="form__container__element__input"
+                            v-model="address.address"
+                        />
+                    </div>
+                </div>
+            </div>
+            <div class="form__container__actions">
+                <template v-if="!pendingSendMultisigTX">
+                    <div class="actions__container">
+                        <div class="actions__container__buttons">
+                            <button
+                                v-if="$listeners['selectOffer']"
+                                :class="[
+                                    'camino__primary--button',
+                                    { 'camino--button--disabled': !formValid },
+                                ]"
+                                @click.prevent="submitCreateOffer"
+                                :disabled="!formValid"
+                            >
+                                {{ $t('earn.rewards.create.submit') }}
+                            </button>
+                        </div>
+                        <Alert variant="warning">
+                            Creating this depositOffer will incurr a fee of
+                            {{ feeAmt }} {{ nativeAssetSymbol }}
+                        </Alert>
+                    </div>
+                </template>
+                <template v-else>
+                    <div class="actions__container">
+                        <Alert v-if="pendingSendMultisigTX" variant="info" style="margin-top: 16px">
+                            {{
+                                $t('earn.validate.pending_multisig.threshold', {
+                                    value: sigValue,
+                                    threshold: pendingSendMultisigTX?.tx.threshold,
+                                })
+                            }}
+                        </Alert>
+                        <Alert style="margin-top: 16px" v-if="SignStatus" variant="info">
+                            {{ $t('earn.validate.pending_multisig.already_signed') }}
+                        </Alert>
+                        <div class="actions__container__buttons">
+                            <button
+                                class="camino__negative--button"
+                                @click.prevent="openAbortModal"
+                            >
+                                {{ $t('transfer.multisig.abort_transaction') }}
+                            </button>
+                            <button
+                                v-if="canExecuteMultisigTx"
+                                :class="['camino__primary--button']"
+                                @click.prevent="issueMultisigTx"
+                            >
+                                {{ $t('transfer.multisig.execute_transaction') }}
+                            </button>
+                            <button
+                                v-else
+                                :class="[
+                                    'camino__primary--button',
+                                    { 'camino--button--disabled': disableSignButton() },
+                                ]"
+                                @click.prevent="signMultisigTx"
+                                :disabled="disableSignButton()"
+                            >
+                                {{ $t('transfer.multisig.sign_transaction') }}
+                            </button>
+                        </div>
+                    </div>
+                    <ModalAbortSigning
+                        ref="modal_abort_signing"
+                        :title="$t('transfer.multisig.abort_transaction')"
+                        :modalText="$t('earn.rewards.abort_modal.message')"
+                        @cancelTx="cancelMultisigTx"
+                    />
+                </template>
+            </div>
+        </form>
+    </div>
+</template>
+<script lang="ts">
+import Alert from '@/components/Alert.vue'
+import AvaxInput from '@/components/misc/AvaxInput.vue'
+import { DAY_MS, ZeroBN } from '@/constants'
+import { bnToBig, cleanAvaxBN, formatDuration } from '@/helpers/helper'
+import { DepositOffer, WalletHelper } from '@/helpers/wallet_helper'
+import AvaAsset from '@/js/AvaAsset'
+import { WalletType } from '@/js/wallets/types'
+import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
+import { BN, Buffer } from '@c4tplatform/caminojs/dist'
+import 'reflect-metadata'
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
+import DateForm from './DateForm.vue'
+
+import { ava, bintools } from '@/AVA'
+import CamInput from '@/components/CamInput.vue'
+import ModalAbortSigning from '@/components/wallet/earn/ModalAbortSigning.vue'
+import { MultisigWallet } from '@/js/wallets/MultisigWallet'
+import { AddDepositOfferTx, Offer, UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
+import { SignatureError } from '@c4tplatform/caminojs/dist/common'
+import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
+@Component({
+    components: {
+        DateForm,
+        AvaxInput,
+        ModalAbortSigning,
+        Alert,
+        CamInput,
+    },
+})
+export default class CreateOfferForm extends Vue {
+    @Prop() isSuite!: boolean
+    addresses: { address: string }[] = [{ address: '' }]
+    helpers = this.globalHelper()
+    offer: DepositOffer = {
+        upgradeVersion: 1,
+        id: '',
+        interestRateNominator: ZeroBN,
+        start: ZeroBN,
+        end: ZeroBN,
+        minAmount: new BN(1000000000),
+        totalMaxAmount: ZeroBN,
+        depositedAmount: ZeroBN,
+        minDuration: 1,
+        maxDuration: 86400,
+        unlockPeriodDuration: 1,
+        noRewardsPeriodDuration: 0,
+        memo: '',
+        flags: ZeroBN,
+        totalMaxRewardAmount: ZeroBN,
+        rewardedAmount: ZeroBN,
+        ownerAddress: '',
+    }
+    pendingOffer: any = null
+    $refs!: {
+        modal_abort_signing: ModalAbortSigning
+    }
+
+    get activeWallet(): MultisigWallet {
+        return this.$store.state.activeWallet
+    }
+    get sigValue() {
+        return this.pendingSendMultisigTX?.tx.owners?.filter((owner) => !!owner.signature)?.length
+    }
+    get SignStatus(): boolean {
+        let isSigned = false
+        this.txOwners.forEach((owner) => {
+            if (
+                this.activeWallet.wallets.find((w) => w?.getAllAddressesP()?.[0] === owner.address)
+            ) {
+                if (owner.signature) isSigned = true
+            }
+        })
+        return isSigned
+    }
+    get minDuration() {
+        return 1
+    }
+    get maxDuration() {
+        return 1 * 365 * DAY_MS
+    }
+
+    get defaultDuration() {
+        return 1
+    }
+
+    get ava_asset(): AvaAsset | null {
+        let ava = this.$store.getters['Assets/AssetAVA']
+        return ava
+    }
+
+    get sunrisePhase(): number {
+        return this.$store.getters['Platform/getSunrisePhase']
+    }
+
+    get nativeAssetSymbol(): string {
+        return this.ava_asset?.symbol ?? ''
+    }
+
+    get isMultisigWallet(): boolean {
+        return this.activeWallet instanceof MultisigWallet
+    }
+
+    get formValid(): boolean {
+        if (this.offer.minDuration > this.offer.maxDuration) return false
+        if (this.offer.maxDuration <= 0) return false
+        if (this.offer.start > this.offer.end) return false
+        return true
+    }
+    get wallet(): WalletType {
+        return this.$store.state.activeWallet
+    }
+    get pendingSendMultisigTX(): SignavaultTx | undefined {
+        return this.$store.getters['Signavault/transactions'].find(
+            (item: SignavaultTx) =>
+                item?.tx?.alias === this.wallet?.getStaticAddress('P') &&
+                WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx) === 'AddDepositOfferTx'
+        )
+    }
+    get feeAmt(): string {
+        return this.formattedAmount(ava.PChain().getTxFee())
+    }
+    formattedAmount(val: BN): string {
+        return `${(Number(val.toString()) / Number(ONEAVAX.toString())).toLocaleString()}`
+    }
+    async mounted() {
+        await this.$store.dispatch('Signavault/updateTransaction')
+    }
+    @Watch('pendingSendMultisigTX')
+    upd() {
+        if (this.pendingSendMultisigTX) {
+            let unsignedTx = new UnsignedTx()
+            unsignedTx.fromBuffer(Buffer.from(this.pendingSendMultisigTX.tx?.unsignedTx, 'hex'))
+            const utx = unsignedTx.getTransaction() as AddDepositOfferTx
+            let offer = utx.getDepositOffer() as Offer
+            this.pendingOffer = {
+                interestRateNominator: bintools
+                    .fromBufferToBN(offer.getInterestRateNominator())
+                    .toString(10),
+                minAmount: bintools.fromBufferToBN(offer.getMinAmount()),
+                totalMaxAmount: bintools.fromBufferToBN(offer.getTotalMaxAmount()),
+                minDuration: Number(bnToBig(bintools.fromBufferToBN(offer.getMinDuration()))),
+                maxDuration: Number(bnToBig(bintools.fromBufferToBN(offer.getMaxDuration()))),
+                unlockPeriodDuration: Number(
+                    bnToBig(bintools.fromBufferToBN(offer.getUnlockPeriodDuration()))
+                ),
+                noRewardsPeriodDuration: Number(
+                    bnToBig(bintools.fromBufferToBN(offer.getNoRewardsPeriodDuration()))
+                ),
+                flags: bintools.fromBufferToBN(offer.getFlags()).toString(10),
+                totalMaxRewardAmount: bintools.fromBufferToBN(offer.getTotalMaxRewardAmount()),
+                memo: offer.getMemo().toString(),
+                ownerAddress: bintools.addressToString(ava.getHRP(), 'P', offer.getOwnerAddress()),
+                start: new Date(
+                    Number(bnToBig(bintools.fromBufferToBN(offer.getStart()))) * 1000
+                ).toISOString(),
+                end: new Date(
+                    Number(bnToBig(bintools.fromBufferToBN(offer.getEnd()))) * 1000
+                ).toISOString(),
+            }
+            if (this.pendingOffer.ownerAddress === ava.PChain().addressFromBuffer(Buffer.alloc(20)))
+                this.pendingOffer.ownerAddress = ''
+        }
+    }
+    async submitCreateOffer(): Promise<void> {
+        if (this.offer.ownerAddress === '') this.offer.ownerAddress = undefined
+        const wallet: WalletType = this.$store.state.activeWallet
+        try {
+            const result = await WalletHelper.buildAddDepositOfferTx(wallet, this.offer)
+            this.offer = {
+                upgradeVersion: 1,
+                id: '',
+                interestRateNominator: ZeroBN,
+                start: ZeroBN,
+                end: ZeroBN,
+                minAmount: new BN(1000000000),
+                totalMaxAmount: ZeroBN,
+                depositedAmount: ZeroBN,
+                minDuration: 1,
+                maxDuration: 86400,
+                unlockPeriodDuration: 1,
+                noRewardsPeriodDuration: 0,
+                memo: '',
+                flags: ZeroBN,
+                totalMaxRewardAmount: ZeroBN,
+                rewardedAmount: ZeroBN,
+                ownerAddress: '',
+            }
+            this.$store.dispatch('Platform/addAllowedAddresses', {
+                depositOfferID: result,
+                allowedAddresses: this.addresses,
+                timestamp: this.offer.start.toNumber(),
+            })
+            this.helpers.dispatchNotification({
+                message: `Create Offer Successful (TX: ${result})`,
+                type: 'success',
+            })
+        } catch (error) {
+            if (error instanceof SignatureError) {
+                await this.$store.dispatch('Signavault/updateTransaction')
+                this.helpers.dispatchNotification({
+                    message: 'Transaction Recorded.',
+                    type: 'success',
+                })
+            } else {
+                let err = error as Error
+                this.helpers.dispatchNotification({
+                    message: err.message,
+                    type: 'error',
+                })
+                return
+            }
+        }
+        this.cancelCreateOffer()
+    }
+    addAddress(): void {
+        if (this.addresses.length >= 128) return
+        this.addresses.push({ address: '' })
+    }
+
+    async updateMultisigTxDetails() {
+        await this.$store.dispatch('Assets/updateUTXOs')
+        await this.$store.dispatch('Signavault/updateTransaction')
+    }
+    async signMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.debug('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingSendMultisigTX) return console.debug('MultiSigTx::sign: Invalid Tx')
+        try {
+            await wallet.addSignatures(this.pendingSendMultisigTX?.tx)
+            this.helpers.dispatchNotification({
+                message: 'Your signature saved successfully!',
+                type: 'success',
+            })
+            this.$store.dispatch('Signavault/updateTransaction')
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: 'Your signature is not saved.',
+                type: 'error',
+            })
+        }
+    }
+    async issueMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.log('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingSendMultisigTX) return console.log('MultiSigTx::sign: Invalid Tx')
+        try {
+            let txID = await wallet.issueExternal(this.pendingSendMultisigTX?.tx)
+            this.$store.dispatch('Assets/updateUTXOs')
+            this.$store.dispatch('Signavault/updateTransaction').then(() => {
+                this.$store.dispatch('updateBalances')
+                this.helpers.dispatchNotification({
+                    message: this.$t('notifications.transfer_success_msg'),
+                    type: 'success',
+                })
+            })
+            this.updateMultisigTxDetails()
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: this.$t('notifications.execute_multisig_transaction_error'),
+                type: 'error',
+            })
+        }
+    }
+    get txOwners() {
+        return this.pendingSendMultisigTX?.tx?.owners ?? []
+    }
+    disableSignButton(): boolean {
+        let isSigned = false
+        this.txOwners.forEach((owner) => {
+            if (
+                this.activeWallet.wallets.find((w) => w?.getAllAddressesP()?.[0] === owner.address)
+            ) {
+                if (owner.signature) isSigned = true
+            }
+        })
+        return isSigned
+    }
+    get canExecuteMultisigTx(): boolean {
+        let signers = 0
+        let threshold = this.pendingSendMultisigTX?.tx?.threshold
+        this.txOwners.forEach((owner) => {
+            if (owner.signature) signers++
+        })
+        if (threshold) return signers >= threshold
+        return false
+    }
+    async cancelMultisigTx() {
+        try {
+            const wallet = this.wallet as MultisigWallet
+            if (this.pendingSendMultisigTX) {
+                // cancel from the wallet
+                await wallet.cancelExternal(this.pendingSendMultisigTX?.tx)
+                this.helpers.dispatchNotification({
+                    message: this.$t('transfer.multisig.transaction_aborted'),
+                    type: 'success',
+                })
+                this.updateMultisigTxDetails()
+            }
+        } catch (err) {
+            console.log(err)
+            this.helpers.dispatchNotification({
+                message: this.$t('transfer.multisig.cancel_transaction_failed'),
+                type: 'error',
+            })
+        }
+    }
+    openAbortModal() {
+        this.$refs.modal_abort_signing.open()
+    }
+    cancelCreateOffer(): void {
+        this.$emit('selectOffer')
+    }
+
+    cleanAvaxBN(val: BN): string {
+        return cleanAvaxBN(val)
+    }
+
+    formatDuration(dur: number): string {
+        return formatDuration(dur)
+    }
+
+    setStartDate(val: string) {
+        this.offer.start = new BN(new Date(val).getTime() / 1000)
+    }
+
+    setEndDate(val: string) {
+        this.offer.end = new BN(new Date(val).getTime() / 1000)
+    }
+
+    setInterestRate(ev: any) {
+        this.offer.interestRateNominator = new BN(ev.target.value)
+    }
+
+    setFlags(ev: any) {
+        this.offer.flags = new BN(ev.target.value)
+    }
+}
+</script>
+<style scoped lang="scss">
+@use '../../../styles/abstracts/mixins';
+.multisig_address {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+.add-new-address {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    &--button {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex: 1;
+    }
+}
+.actions__container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    &__buttons {
+        display: flex;
+        gap: 16px;
+    }
+}
+.circle {
+    border: var(--primary-border);
+    cursor: pointer;
+    justify-content: center;
+    align-items: center;
+    display: flex;
+    border-radius: 100%;
+    border-width: 2px;
+    padding: 10px;
+}
+input {
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--camino-slate-slate-600);
+    &:disabled {
+        border: 1px solid var(--camino-slate-slate-600) !important;
+    }
+}
+.form__container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: flex-start;
+    color: var(--primary-color);
+
+    &__element {
+        width: 450px;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+        align-self: stretch;
+        &__label {
+            color: var(--primary-color);
+            font-family: 'Inter';
+            font-size: 14px;
+            font-style: normal;
+            font-weight: 600;
+            line-height: 20px;
+        }
+        &__input {
+            width: 450px !important;
+        }
+        &__addresses {
+            width: 100%;
+        }
+        &__new-addresses {
+            width: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+    }
+    &__actions {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+    }
+}
+</style>

--- a/src/components/wallet/earn/CreateOfferForm.vue
+++ b/src/components/wallet/earn/CreateOfferForm.vue
@@ -7,11 +7,13 @@
                         {{ $t('earn.rewards.create.memo').toString() }}
                     </label>
                     <CamInput
-                        class="form__container__element__input"
-                        :placeholder="`Memo`"
                         v-model="offer.memo"
+                        :placeholder="$t('earn.rewards.create.memo')"
+                        :error="nameLengthError"
+                        :errorMessage="$t('earn.rewards.errors.title')"
                     />
                 </div>
+
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.offer_start') }}
@@ -24,6 +26,7 @@
                         @change_end="setStartDate"
                     ></DateForm>
                 </div>
+
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.offer_end') }}
@@ -36,6 +39,7 @@
                         @change_end="setEndDate"
                     ></DateForm>
                 </div>
+
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.min_amount') }}
@@ -43,14 +47,28 @@
                     <AvaxInput
                         v-model="offer.minAmount"
                         :initial="offer.minAmount"
+                        :max="maxDepositAmount"
                         :camInput="true"
+                        :error="minAmountError"
+                        :errorMessage="
+                            $t('earn.rewards.errors.min_amount', {
+                                minAmount: 0.001,
+                                symbol: nativeAssetSymbol,
+                            })
+                        "
                     ></AvaxInput>
                 </div>
+
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.total_max_amount') }}
                     </label>
-                    <AvaxInput v-model="offer.totalMaxAmount" :camInput="true"></AvaxInput>
+                    <AvaxInput
+                        v-model="offer.totalMaxAmount"
+                        :initial="offer.totalMaxAmount"
+                        :max="maxDepositAmount"
+                        :camInput="true"
+                    ></AvaxInput>
                 </div>
 
                 <div class="form__container__element">
@@ -60,15 +78,12 @@
                     <CamInput
                         class="form__container__element__input"
                         :placeholder="`minDuration`"
-                        v-model.number="offer.minDuration"
-                    />
-                    <!-- <input
-                        class="form__container__element__input"
-                        type="number"
                         v-model="offer.minDuration"
-                        inputmode="numeric"
-                    /> -->
+                        :error="minDurationError"
+                        :errorMessage="`Min duration must be greater than 0`"
+                    />
                 </div>
+
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.max_duration') }}
@@ -76,42 +91,34 @@
                     <CamInput
                         class="form__container__element__input"
                         :placeholder="`maxDuration`"
-                        v-model.number="offer.maxDuration"
-                    />
-                    <!-- <input
-                        class="form__container__element__input"
-                        type="number"
                         v-model="offer.maxDuration"
-                        inputmode="numeric"
-                    /> -->
+                        :error="maxDurationError"
+                        :errorMessage="`Max duration must be greater than min duration`"
+                    />
                 </div>
+
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.unlock_duration') }}
                     </label>
                     <CamInput
-                        class="form__container__element__input"
-                        :placeholder="`unlockPeriodDuration`"
-                        v-model.number="offer.unlockPeriodDuration"
-                    />
-                    <!-- <input
-                        class="form__container__element__input"
-                        type="number"
                         v-model="offer.unlockPeriodDuration"
-                        inputmode="numeric"
-                    /> -->
+                        :placeholder="`unlockPeriodDuration`"
+                        :error="unlockDurationError"
+                        :errorMessage="`Unlock duration must be greater than 0`"
+                    />
                 </div>
+
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.interrest_rate') }}
                     </label>
-                    <input
-                        class="form__container__element__input"
-                        type="number"
-                        :value="offer.interestRateNominator.toString(10)"
+                    <CamInput
+                        v-model="interestRateNominator"
                         v-on:input="setInterestRate"
-                        min="0"
-                        inputmode="numeric"
+                        :placeholder="`interestRateNominator`"
+                        :error="interestRateAndTotalMaxRewardAmountError"
+                        :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
                     />
                 </div>
                 <div class="form__container__element">
@@ -119,26 +126,24 @@
                         {{ $t('earn.rewards.create.no_rewards_duration') }}
                     </label>
                     <CamInput
-                        class="form__container__element__input"
-                        :placeholder="`noRewardsPeriodDuration`"
-                        v-model.number="offer.noRewardsPeriodDuration"
-                    />
-                    <!-- <input
-                        class="form__container__element__input"
-                        type="number"
                         v-model="offer.noRewardsPeriodDuration"
-                        inputmode="numeric"
-                    /> -->
+                        :placeholder="`noRewardsPeriodDuration`"
+                        :error="noRewardsPeriodDurationError"
+                        :errorMessage="`No rewards duration must be greater or equal to 0`"
+                    />
                 </div>
                 <div class="form__container__element">
                     <label class="form__container__element__label">
                         {{ $t('earn.rewards.create.total_max_reward_amount') }}
                     </label>
-                    <AvaxInput
-                        v-model="offer.totalMaxRewardAmount"
+                    <CamInput
+                        v-model="totalMaxRewardAmount"
+                        v-on:input="setTotalMaxRewardAmount"
+                        :placeholder="`totalMaxRewardAmount`"
                         :readonly="sunrisePhase === 0"
-                        :camInput="true"
-                    ></AvaxInput>
+                        :error="interestRateAndTotalMaxRewardAmountError"
+                        :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
+                    ></CamInput>
                 </div>
                 <div class="form__container__element">
                     <label class="form__container__element__label">
@@ -163,6 +168,8 @@
                         :placeholder="`ownerAddress`"
                         v-model.number="offer.ownerAddress"
                         :disabled="sunrisePhase === 0"
+                        :error="ownerAddressCheck()"
+                        :errorMessage="ownerAddressCheck()"
                     />
                     <!-- <input
                         class="form__container__element__input"
@@ -181,13 +188,25 @@
                         :key="index"
                         class="form__container__element__addresses"
                     >
-                        <!-- <div class="circle number">{{ index + 1 }}</div> -->
-                        <input
-                            class="form__container__element__input"
-                            v-model="address.address"
-                            style="margin-bottom: 8px"
-                        />
+                        <div class="addresses_container">
+                            <button @click="removeAddress(index)" class="circle delete-button">
+                                <CamTooltip
+                                    :content="$t('edit_multisig.label.remove_owner')"
+                                    placement="left"
+                                >
+                                    <fa icon="minus"></fa>
+                                </CamTooltip>
+                            </button>
+                            <!-- <div class="circle number">{{ index + 1 }}</div> -->
+                            <CamInput
+                                class="form__container__element__input"
+                                v-model="address.address"
+                            />
+                        </div>
                     </div>
+                    <Alert style="margin-top: 16px" variant="negative" v-if="validAddressError">
+                        {{ $t('edit_multisig.errors.invalid_addresses') }}
+                    </Alert>
                     <div class="form__container__element__new-addresses">
                         <button @click.prevent="addAddress" class="circle plus-button">
                             <fa icon="plus"></fa>
@@ -374,9 +393,22 @@
                 </div>
             </div>
             <div class="form__container__actions">
+                <div class="actions__container">
+                    <Alert v-if="hasExclusiveTotalMaxAmountOrReward" variant="negative">
+                        can only use either TotalMaxAmount or TotalMaxRewardAmount
+                    </Alert>
+                    <Alert v-if="isMinDurationLessThanNoRewardsPeriod" variant="negative">
+                        deposit offer minimum duration ({{ offer.minDuration }}) is less than
+                        no-rewards period duration ({{ offer.noRewardsPeriodDuration }})
+                    </Alert>
+                </div>
                 <template v-if="!pendingSendMultisigTX">
                     <div class="actions__container">
-                        <div class="actions__container__buttons">
+                        <Alert variant="warning">
+                            Creating this depositOffer will incurr a fee of
+                            {{ feeAmt }} {{ nativeAssetSymbol }}
+                        </Alert>
+                        <!-- <div class="actions__container__buttons">
                             <button
                                 v-if="$listeners['selectOffer']"
                                 :class="[
@@ -388,11 +420,17 @@
                             >
                                 {{ $t('earn.rewards.create.submit') }}
                             </button>
+                        </div> -->
+                        <div class="actions__container__buttons">
+                            <CamBtn
+                                v-if="$listeners['selectOffer']"
+                                variant="primary"
+                                @click.prevent="submitCreateOffer"
+                                :disabled="!formValid"
+                            >
+                                {{ $t('earn.rewards.create.submit') }}
+                            </CamBtn>
                         </div>
-                        <Alert variant="warning">
-                            Creating this depositOffer will incurr a fee of
-                            {{ feeAmt }} {{ nativeAssetSymbol }}
-                        </Alert>
                     </div>
                 </template>
                 <template v-else>
@@ -461,12 +499,17 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 import DateForm from './DateForm.vue'
 
 import { ava, bintools } from '@/AVA'
+import CamBtn from '@/components/CamBtn.vue'
 import CamInput from '@/components/CamInput.vue'
 import ModalAbortSigning from '@/components/wallet/earn/ModalAbortSigning.vue'
+import { isValidPChainAddress } from '@/helpers/address_helper'
 import { MultisigWallet } from '@/js/wallets/MultisigWallet'
 import { AddDepositOfferTx, Offer, UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
 import { SignatureError } from '@c4tplatform/caminojs/dist/common'
 import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
+
+const MAX_NAME_BYTE_SIZE = 64
+
 @Component({
     components: {
         DateForm,
@@ -474,19 +517,25 @@ import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
         ModalAbortSigning,
         Alert,
         CamInput,
+        CamBtn,
     },
 })
 export default class CreateOfferForm extends Vue {
     @Prop() isSuite!: boolean
+    @Prop() maxDepositAmount!: BN
+
     addresses: { address: string }[] = [{ address: '' }]
+    // @ts-ignore
     helpers = this.globalHelper()
+    interestRateNominator = ZeroBN
+    totalMaxRewardAmount = ZeroBN
     offer: DepositOffer = {
         upgradeVersion: 1,
         id: '',
         interestRateNominator: ZeroBN,
         start: ZeroBN,
         end: ZeroBN,
-        minAmount: new BN(1000000000),
+        minAmount: new BN(1000000),
         totalMaxAmount: ZeroBN,
         depositedAmount: ZeroBN,
         minDuration: 1,
@@ -502,6 +551,118 @@ export default class CreateOfferForm extends Vue {
     pendingOffer: any = null
     $refs!: {
         modal_abort_signing: ModalAbortSigning
+    }
+    @Watch('interestRateNominator')
+    onInterestRateNominatorChange() {
+        this.offer.interestRateNominator = new BN(this.interestRateNominator)
+    }
+    @Watch('totalMaxRewardAmount')
+    onTotalMaxRewardAmountChange() {
+        this.offer.totalMaxRewardAmount = new BN(this.totalMaxRewardAmount)
+    }
+    ownerAddressCheck() {
+        if (!this.offer.ownerAddress) return ''
+        return !isValidPChainAddress(this.offer.ownerAddress as string) ||
+            this.offer.ownerAddress != this.wallet?.getStaticAddress('P')
+            ? 'Invalid address'
+            : ''
+    }
+
+    get hasExclusiveTotalMaxAmountOrReward() {
+        const hasTotalMaxAmount =
+            BN.isBN(this.offer.totalMaxAmount) && !this.offer.totalMaxAmount.isZero()
+        const hasTotalMaxRewardAmount =
+            BN.isBN(this.offer.totalMaxRewardAmount) && !this.offer.totalMaxRewardAmount.isZero()
+
+        return hasTotalMaxAmount && hasTotalMaxRewardAmount
+    }
+
+    get isMinDurationLessThanNoRewardsPeriod() {
+        return Number(this.offer.unlockPeriodDuration) < Number(this.offer.noRewardsPeriodDuration)
+    }
+
+    get nameLengthError() {
+        const bytes = new TextEncoder().encode(this.offer.memo)
+        return bytes.length > MAX_NAME_BYTE_SIZE || bytes.length === 0
+    }
+    get minAmountError() {
+        if (/[a-zA-Z]/.test(this.offer.minAmount.toString())) return true
+        return this.offer.minAmount.lt(new BN(1000000))
+    }
+
+    get maxAmountError() {
+        if (/[a-zA-Z]/.test(this.offer.totalMaxAmount.toString())) return true
+        return this.offer.totalMaxAmount.lt(this.offer.minAmount)
+    }
+
+    get minDurationError() {
+        const minDurationString = String(this.offer.minDuration)
+
+        return (
+            isNaN(this.offer.minDuration) ||
+            /[a-zA-Z]/.test(minDurationString) ||
+            this.offer.minDuration < 0 ||
+            /^0[0-9]/.test(minDurationString)
+        )
+    }
+
+    get maxDurationError() {
+        const maxDurationString = String(this.offer.maxDuration)
+
+        return (
+            isNaN(this.offer.maxDuration) ||
+            /[a-zA-Z]/.test(maxDurationString) ||
+            this.offer.maxDuration < 0 ||
+            /^0[0-9]/.test(maxDurationString) ||
+            this.offer.maxDuration < this.offer.minDuration
+        )
+    }
+
+    get unlockDurationError() {
+        const unlockDurationString = String(this.offer.unlockPeriodDuration)
+
+        return (
+            isNaN(this.offer.unlockPeriodDuration) ||
+            /[a-zA-Z]/.test(unlockDurationString) ||
+            this.offer.unlockPeriodDuration < 0 ||
+            /^0[0-9]/.test(unlockDurationString)
+        )
+    }
+
+    get noRewardsPeriodDurationError() {
+        const noRewardsPeriodDurationString = String(this.offer.noRewardsPeriodDuration)
+
+        return (
+            isNaN(this.offer.noRewardsPeriodDuration) ||
+            /[a-zA-Z]/.test(noRewardsPeriodDurationString) ||
+            this.offer.noRewardsPeriodDuration < 0 ||
+            /^0[0-9]/.test(noRewardsPeriodDurationString)
+        )
+    }
+
+    get totalMaxRewardAmountError() {
+        if (!BN.isBN(this.offer.totalMaxRewardAmount)) {
+            try {
+                this.offer.totalMaxRewardAmount = new BN(this.offer.totalMaxRewardAmount)
+            } catch (e) {
+                console.error('totalMaxRewardAmount is not a valid BN object:', e)
+                return true
+            }
+        }
+
+        if (/[a-zA-Z]/.test(this.offer.totalMaxRewardAmount.toString())) return true
+        return this.offer.totalMaxRewardAmount.lt(ZeroBN)
+    }
+
+    get interestRateAndTotalMaxRewardAmountError() {
+        // Ensure that the values are instances of BN and then compare
+        const interestRateNotZero =
+            BN.isBN(this.offer.interestRateNominator) && !this.offer.interestRateNominator.isZero()
+        const totalMaxRewardAmountNotZero =
+            BN.isBN(this.offer.totalMaxRewardAmount) && !this.offer.totalMaxRewardAmount.isZero()
+
+        // Error if only one of them is non-zero (XOR condition)
+        return interestRateNotZero !== totalMaxRewardAmountNotZero
     }
 
     get activeWallet(): MultisigWallet {
@@ -550,8 +711,17 @@ export default class CreateOfferForm extends Vue {
     }
 
     get formValid(): boolean {
-        if (this.offer.minDuration > this.offer.maxDuration) return false
-        if (this.offer.maxDuration <= 0) return false
+        if (
+            this.nameLengthError ||
+            this.minAmountError ||
+            this.minDurationError ||
+            this.maxDurationError ||
+            this.unlockDurationError ||
+            this.noRewardsPeriodDurationError ||
+            this.hasExclusiveTotalMaxAmountOrReward ||
+            this.isMinDurationLessThanNoRewardsPeriod
+        )
+            return false
         if (this.offer.start > this.offer.end) return false
         return true
     }
@@ -661,11 +831,23 @@ export default class CreateOfferForm extends Vue {
         }
         this.cancelCreateOffer()
     }
+    get validAddressError(): boolean {
+        const filledAddresses = this.addresses.filter((a) => a.address !== '')
+
+        for (const addressObj of filledAddresses) {
+            if (!isValidPChainAddress(addressObj.address)) return true
+        }
+
+        return false
+    }
     addAddress(): void {
         if (this.addresses.length >= 128) return
         this.addresses.push({ address: '' })
     }
-
+    removeAddress(index: number): void {
+        this.addresses.splice(index, 1)
+        if (this.addresses.length === 0) this.addAddress()
+    }
     async updateMultisigTxDetails() {
         await this.$store.dispatch('Assets/updateUTXOs')
         await this.$store.dispatch('Signavault/updateTransaction')
@@ -779,7 +961,17 @@ export default class CreateOfferForm extends Vue {
     }
 
     setInterestRate(ev: any) {
-        this.offer.interestRateNominator = new BN(ev.target.value)
+        if (ev && ev.target) {
+            const interestRateValue = ev.target.value
+            this.offer.interestRateNominator = new BN(interestRateValue)
+        }
+    }
+
+    setTotalMaxRewardAmount(ev: any) {
+        if (ev && ev.target) {
+            const totalMaxRewardAmountValue = ev.target.value
+            this.offer.totalMaxRewardAmount = new BN(totalMaxRewardAmountValue)
+        }
     }
 
     setFlags(ev: any) {
@@ -844,7 +1036,7 @@ input {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        gap: 4px;
+        gap: 1.25rem;
         align-self: stretch;
         &__label {
             color: var(--primary-color);
@@ -871,6 +1063,69 @@ input {
         display: flex;
         align-items: center;
         gap: 16px;
+    }
+}
+.cam-input {
+    width: 100%;
+}
+
+.addresses_container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+}
+
+.circle {
+    border: 2px solid var(--camino-slate-slate-600);
+    cursor: pointer;
+    justify-content: center;
+    align-items: center;
+    display: flex;
+    border-radius: 100%;
+    padding: 10px;
+}
+
+.number {
+    width: 35px !important;
+    height: 35px !important;
+    cursor: default;
+}
+
+.plus-button {
+    border: 2px solid var(--camino-success-color);
+    font-size: 10px;
+    width: 40px !important;
+    height: 40px !important;
+    svg {
+        color: var(--camino-success-color);
+    }
+}
+
+.delete-button {
+    border: 2px solid var(--camino-error-color);
+    width: 35px !important;
+    height: 35px !important;
+    svg {
+        color: var(--camino-error-color);
+    }
+}
+.delete-button.mobile {
+    display: none;
+}
+
+.delete-button.desktop {
+    display: flex;
+}
+
+@include mixins.mobile-device {
+    .delete-button.mobile {
+        display: flex;
+    }
+
+    .delete-button.desktop {
+        display: none;
     }
 }
 </style>

--- a/src/components/wallet/earn/DepositOffers.vue
+++ b/src/components/wallet/earn/DepositOffers.vue
@@ -1,29 +1,18 @@
 <template>
     <div v-if="hasOffers">
+        <h1 class="create-offer-header" v-if="isSuite">Create new DepositOffer</h1>
         <h4 class="balance">
             {{ $t('earn.offer.balance') }}: {{ cleanAvaxBN(maxDepositAmount) }}
             {{ nativeAssetSymbol }}
-            <button v-if="$data.depositOffer" @click="closeOffer" class="close_offer">
-                <fa icon="times"></fa>
-            </button>
         </h4>
         <transition name="fade" mode="out-in">
-            <div v-if="$data.depositOffer" class="user_offers" key="offer">
-                <DepositOfferCard
-                    :key="'os'"
-                    :offer="$data.depositOffer"
-                    :maxDepositAmount="maxDepositAmount"
-                    class="reward_card"
-                ></DepositOfferCard>
-                <DepositForm
-                    :key="'of'"
-                    :offer="$data.depositOffer"
-                    :maxDepositAmount="maxDepositAmount"
-                    @selectOffer="selectOffer"
-                    class="reward_card"
-                ></DepositForm>
-            </div>
-            <div v-else class="user_offers" key="list">
+            <CreateOfferForm
+                :isSuite="isSuite"
+                v-if="$data.createOffer"
+                key="create"
+                @selectOffer="selectOffer"
+            ></CreateOfferForm>
+            <div class="user_offers" key="list">
                 <DepositOfferCard
                     v-for="(o, i) in platformOffers"
                     :key="'o' + i"
@@ -39,25 +28,38 @@
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
-import DepositOfferCard from './DepositOfferCard.vue'
-import DepositForm from './DepositForm.vue'
+import CreateOfferForm from '@/components/wallet/earn/CreateOfferForm.vue'
+import DepositForm from '@/components/wallet/earn/DepositForm.vue'
+import DepositOfferCard from '@/components/wallet/earn/DepositOfferCard.vue'
 import { cleanAvaxBN } from '@/helpers/helper'
 
+import ModalAbortSigning from '@/components/wallet/earn/ModalAbortSigning.vue'
 import { BN } from '@c4tplatform/caminojs/dist'
 import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm/interfaces'
 
 @Component({
     components: {
+        CreateOfferForm,
         DepositOfferCard,
         DepositForm,
+        ModalAbortSigning,
     },
     data: () => ({
         depositOffer: undefined,
+        createOffer: false,
     }),
 })
 export default class DepositOffers extends Vue {
+    @Prop() isSuite?: boolean
+    helpers = this.globalHelper()
+    async beforeMount() {
+        if (this.isSuite) {
+            this.addOffer()
+        }
+    }
+
     get platformOffers(): DepositOffer[] {
         return this.$store.getters['Platform/depositOffers'](true)
     }
@@ -76,16 +78,24 @@ export default class DepositOffers extends Vue {
         return this.$store.getters['Assets/AssetAVA']?.symbol ?? ''
     }
 
+    get canAddOffers(): boolean {
+        return this.$store.getters['Platform/isOfferCreator']
+    }
     cleanAvaxBN(val: BN): string {
         return cleanAvaxBN(val)
     }
 
     selectOffer(offer: DepositOffer): void {
         this.$data.depositOffer = offer
+        if (offer === undefined && !this.isSuite) this.$data.createOffer = false
+    }
+    addOffer(): void {
+        this.$data.createOffer = true
     }
 
     closeOffer(): void {
         this.$data.depositOffer = undefined
+        this.$data.createOffer = false
     }
 }
 </script>
@@ -97,8 +107,13 @@ export default class DepositOffers extends Vue {
 }
 
 .balance {
-    font-weight: 500;
-    padding-bottom: 10px;
+    color: var(--primary-color);
+    font-family: 'Inter';
+    font-size: 20px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 32px;
+    margin-bottom: 20px;
 }
 
 .user_offers {
@@ -111,6 +126,16 @@ export default class DepositOffers extends Vue {
 
 .claimables {
     margin-bottom: 10px;
+}
+
+.create-offer-header {
+    color: var(--primary-color);
+    font-family: 'Inter';
+    font-size: 28px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: 36px;
+    margin-bottom: 24px;
 }
 
 @include mixins.medium-device {

--- a/src/components/wallet/earn/DepositOffers.vue
+++ b/src/components/wallet/earn/DepositOffers.vue
@@ -11,6 +11,7 @@
                 v-if="$data.createOffer"
                 key="create"
                 @selectOffer="selectOffer"
+                :maxDepositAmount="maxDepositAmount"
             ></CreateOfferForm>
             <div class="user_offers" key="list">
                 <DepositOfferCard

--- a/src/components/wallet/earn/DepositRewardCard.vue
+++ b/src/components/wallet/earn/DepositRewardCard.vue
@@ -1,0 +1,655 @@
+<template>
+    <div class="offer_row">
+        <h3 class="offer_title">{{ rewardTitle }}</h3>
+        <div class="offer_detail">
+            <div class="offer_detail_left">
+                <div>
+                    <label>{{ $t('earn.rewards.active_earning.deposit_start') }}:</label>
+                    <p class="reward">{{ startDate }}</p>
+                </div>
+                <div>
+                    <label>{{ $t('earn.rewards.active_earning.deposit_end') }}:</label>
+                    <p class="reward">{{ endDate }}</p>
+                </div>
+                <div>
+                    <label>{{ $t('earn.rewards.offer.min_deposit') }}:</label>
+                    <p class="reward">{{ cleanAvaxBN(minLock) }} CAM</p>
+                </div>
+                <div>
+                    <label>{{ $t('earn.rewards.offer.reward') }}:</label>
+                    <p class="reward">{{ rewardPercent }} %</p>
+                </div>
+            </div>
+            <div class="offer_detail_right">
+                <div>
+                    <label>{{ $t('earn.rewards.active_earning.deposited_amount') }}:</label>
+                    <p class="reward">
+                        {{ cleanAvaxBN(reward.deposit.amount) }} {{ nativeAssetSymbol }}
+                    </p>
+                </div>
+                <div>
+                    <label>{{ $t('earn.rewards.active_earning.pending_reward') }}:</label>
+                    <p class="reward">
+                        {{ cleanAvaxBN(reward.amountToClaim) }} {{ nativeAssetSymbol }}
+                    </p>
+                </div>
+                <div>
+                    <label>{{ $t('earn.rewards.active_earning.already_claimed') }}:</label>
+                    <p class="reward">
+                        {{ cleanAvaxBN(reward.deposit.claimedRewardAmount) }}
+                        {{ nativeAssetSymbol }}
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div v-if="!isMultiSig" class="button_group">
+            <v-btn
+                class="claim_button button_primary"
+                @click="openModal"
+                :disabled="isClaimDisabled"
+            >
+                {{ $t('earn.rewards.active_earning.claim') }}
+            </v-btn>
+        </div>
+        <template v-else>
+            <div v-if="signatureStatus(reward.deposit.depositTxID) === 2" class="button_group">
+                <v-btn
+                    class="claim_button button_secondary"
+                    @click="openModal"
+                    :disabled="isClaimDisabled"
+                >
+                    {{ $t('earn.rewards.active_earning.execute_claim') }}
+                </v-btn>
+                <v-btn class="claim_button button_primary" @click="openAbortModal">
+                    {{ $t('earn.rewards.active_earning.abort') }}
+                </v-btn>
+            </div>
+            <div
+                v-else-if="signatureStatus(reward.deposit.depositTxID) === -1 && disclamer"
+                class="button_group"
+            >
+                <v-btn
+                    class="claim_button bordered_button"
+                    @click="openModal"
+                    :disabled="isClaimDisabled"
+                >
+                    {{ $t('earn.rewards.active_earning.initiate_transaction') }}
+                </v-btn>
+                <v-btn class="claim_button button_primary" @click="disclamer = false">
+                    {{ $t('earn.rewards.active_earning.cancel') }}
+                </v-btn>
+            </div>
+            <div
+                v-else-if="
+                    signatureStatus(reward.deposit.depositTxID) === 1 &&
+                    !alreadySigned(reward.deposit.depositTxID)
+                "
+                class="button_group"
+            >
+                <v-btn
+                    class="claim_button bordered_button"
+                    @click="signMultisigTx"
+                    :disabled="alreadySigned(reward.deposit.depositTxID)"
+                >
+                    {{ $t('earn.rewards.active_earning.sign') }}
+                </v-btn>
+                <v-btn class="claim_button button_primary" @click="openAbortModal">
+                    {{ $t('earn.rewards.active_earning.abort') }}
+                </v-btn>
+            </div>
+            <div
+                v-else-if="
+                    signatureStatus(reward.deposit.depositTxID) === 1 &&
+                    alreadySigned(reward.deposit.depositTxID)
+                "
+                class="button_group"
+            >
+                <v-btn
+                    class="claim_button bordered_button"
+                    @click="signMultisigTx"
+                    :disabled="alreadySigned(reward.deposit.depositTxID)"
+                >
+                    {{
+                        $t('earn.rewards.active_earning.signed', {
+                            nbSigners: numberOfSignatures,
+                            threshold: threshold,
+                        })
+                    }}
+                </v-btn>
+                <v-btn class="claim_button button_primary" @click="openAbortModal">
+                    {{ $t('earn.rewards.active_earning.abort') }}
+                </v-btn>
+            </div>
+            <div v-else class="button_group">
+                <v-btn
+                    class="claim_button button_primary"
+                    @click="disclamer = true"
+                    :disabled="isClaimDisabled || disallowedClaim(reward.deposit.depositTxID)"
+                >
+                    {{ $t('earn.rewards.active_earning.claim') }}
+                </v-btn>
+            </div>
+            <div v-if="disclamer && !alreadySigned(reward.deposit.depositTxID)" class="err">
+                {{ $t('earn.rewards.active_earning.are_you_sure') }}
+            </div>
+        </template>
+        <ModalClaimDepositReward
+            ref="modal_claim_reward"
+            :depositTxID="reward.deposit.depositTxID"
+            :amount="reward.amountToClaim"
+            :rewardOwner="reward.deposit.rewardOwner"
+            :canExecuteMultisigTx="canExecuteMultisigTx"
+        />
+        <ModalAbortSigning
+            ref="modal_abort_signing"
+            :title="$t('earn.rewards.abort_modal.title')"
+            :modalText="$t('earn.rewards.abort_modal.message')"
+            @cancelTx="cancelMultisigTx"
+        />
+        <!-- <ModalClaimReward
+            ref="modal_claim_reward"
+            :depositTxID="reward.deposit.depositTxID"
+            :amount="reward.amountToClaim"
+            :rewardOwner="reward.deposit.rewardOwner"
+        /> -->
+    </div>
+</template>
+<script lang="ts">
+import 'reflect-metadata'
+import { Component, Prop, Vue } from 'vue-property-decorator'
+
+import ModalClaimReward from '@/components/modals/ClaimRewardModal.vue'
+import { cleanAvaxBN } from '@/helpers/helper'
+import AvaAsset from '@/js/AvaAsset'
+import { PlatformRewardDeposit } from '@/store/modules/platform/types'
+
+import { bintools } from '@/AVA'
+import { ZeroBN } from '@/constants'
+import { WalletHelper } from '@/helpers/wallet_helper'
+import { MultisigWallet } from '@/js/wallets/MultisigWallet'
+import { WalletType } from '@/js/wallets/types'
+import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
+import { BN, Buffer } from '@c4tplatform/caminojs/dist'
+import { ClaimTx, UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
+import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm/interfaces'
+import { ModelMultisigTxOwner } from '@c4tplatform/signavaultjs'
+import ModalAbortSigning from './ModalAbortSigning.vue'
+import ModalClaimDepositReward from './ModalClaimDepositReward.vue'
+
+@Component({
+    components: {
+        ModalClaimReward,
+        ModalClaimDepositReward,
+        ModalAbortSigning,
+    },
+})
+export default class DepositRewardCard extends Vue {
+    now: number = Date.now()
+    intervalID: any = null
+    claimDisabled: boolean = true
+    disclamer: boolean = false
+    helpers = this.globalHelper()
+    // signedDepositID: string = ''
+    @Prop() reward!: PlatformRewardDeposit
+
+    $refs!: {
+        // modal_claim_reward: ModalClaimReward
+        modal_claim_reward: ModalClaimDepositReward
+        modal_abort_signing: ModalAbortSigning
+    }
+
+    openAbortModal() {
+        this.$refs.modal_abort_signing.open()
+    }
+    updateNow() {
+        this.now = Date.now()
+    }
+
+    created() {
+        this.intervalID = setInterval(() => {
+            this.updateNow()
+        }, 2000)
+    }
+    destroyed() {
+        clearInterval(this.intervalID)
+    }
+
+    get activeWallet(): WalletType {
+        return this.$store.state.activeWallet
+    }
+    private get pendingSendMultisigTX(): SignavaultTx | undefined {
+        return this.$store.getters['Signavault/transactions'].find(
+            (item: any) =>
+                item?.tx?.alias === this.activeWallet.getStaticAddress('P') &&
+                WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx) === 'ClaimTx'
+        )
+    }
+    async signMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.debug('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingSendMultisigTX) return console.debug('MultiSigTx::sign: Invalid Tx')
+        try {
+            await wallet.addSignatures(this.pendingSendMultisigTX?.tx)
+            this.helpers.dispatchNotification({
+                message: this.$t('notifications.multisig_transaction_saved'),
+                type: 'success',
+            })
+            this.$store.dispatch('Signavault/updateTransaction')
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: this.$t('multisig_transaction_not_saved'),
+                type: 'error',
+            })
+            this.disclamer = false
+        }
+    }
+    private async issueMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.error('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingSendMultisigTX) return console.error('MultiSigTx::sign: Invalid Tx')
+        try {
+            await wallet.issueExternal(this.pendingSendMultisigTX?.tx)
+            this.helpers.dispatchNotification({
+                message: this.$t('notifications.transfer_success_msg'),
+                type: 'success',
+            })
+            this.updateMultisigTxDetails()
+            this.$store.dispatch('Platform/updateActiveDepositOffer')
+            this.$store.dispatch('Signavault/updateTransaction')
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: this.$t('notifications.execute_multisig_transaction_error'),
+                type: 'error',
+            })
+        }
+    }
+
+    async cancelMultisigTx() {
+        try {
+            const wallet = this.activeWallet as MultisigWallet
+            if (this.pendingSendMultisigTX) {
+                // cancel from the wallet
+                await wallet.cancelExternal(this.pendingSendMultisigTX?.tx)
+                await this.$store.dispatch('Signavault/updateTransaction')
+                this.helpers.dispatchNotification({
+                    message: this.$t('transfer.multisig.transaction_aborted'),
+                    type: 'success',
+                })
+            }
+        } catch (err) {
+            console.log(err)
+            this.helpers.dispatchNotification({
+                message: this.$t('transfer.multisig.cancel_transaction_failed'),
+                type: 'error',
+            })
+        }
+    }
+    private async updateMultisigTxDetails() {
+        if (this.pendingSendMultisigTX) {
+            let unsignedTx = new UnsignedTx()
+            unsignedTx.fromBuffer(Buffer.from(this.pendingSendMultisigTX.tx?.unsignedTx, 'hex'))
+            const utx = unsignedTx.getTransaction() as ClaimTx
+            const claimAmounts = utx.getClaimAmounts()
+        }
+    }
+    get numberOfSignatures(): number {
+        let signers = 0
+        this.txOwners(this.reward.deposit.depositTxID).forEach((owner) => {
+            if (owner.signature) signers++
+        })
+        return signers
+    }
+
+    get threshold(): number {
+        return this.pendingSendMultisigTX?.tx?.threshold ?? 0
+    }
+
+    getPendingMultisigTx(depositTxID: string): SignavaultTx | undefined {
+        const tx = this.pendingSendMultisigTX
+        if (!tx) return undefined
+
+        const depositId = this.signedDepositID()
+        if (depositId === depositTxID) return tx
+        else return undefined
+    }
+    signedDepositID() {
+        const tx = this.pendingSendMultisigTX
+
+        if (!tx) return undefined
+
+        const unsignedTx = new UnsignedTx()
+        unsignedTx.fromBuffer(Buffer.from(tx.tx?.unsignedTx, 'hex'))
+        const utx = unsignedTx.getTransaction() as ClaimTx
+        const claimAmounts = utx.getClaimAmounts()
+
+        return bintools.cb58Encode(claimAmounts[0].getID())
+    }
+    txOwners(depositTxID: string): ModelMultisigTxOwner[] | [] {
+        return this.getPendingMultisigTx(depositTxID)?.tx?.owners ?? []
+    }
+    signatureStatus(depositTxID: string): number {
+        if (!this.getPendingMultisigTx(depositTxID)?.tx) return -1
+        else if (!this.canExecuteMultisigTx(depositTxID)) return 1
+        else if (this.canExecuteMultisigTx(depositTxID)) return 2
+
+        return -1
+    }
+    canExecuteMultisigTx(depositTxID: string): boolean {
+        let signers = 0
+        let threshold = this.getPendingMultisigTx(depositTxID)?.tx?.threshold
+        const txOwners = this.txOwners(depositTxID)
+
+        txOwners.forEach((owner) => {
+            if (owner.signature) signers++
+        })
+        if (threshold) return signers >= threshold
+        return false
+    }
+
+    alreadySigned(depositTxID: string): boolean {
+        const txOwners = this.txOwners(depositTxID)
+        if (!txOwners) return false
+
+        const walletAddresses = (this.activeWallet as MultisigWallet)?.wallets?.map(
+            (w) => w?.getAllAddressesP()?.[0]
+        )
+        if (!walletAddresses) return false
+
+        const isSigned = txOwners.some((owner) => {
+            if (!owner) return false
+            const isOwnerSigned = owner.signature && walletAddresses.includes(owner.address)
+            return isOwnerSigned
+        })
+
+        return isSigned
+    }
+    disallowedClaim(depositTxID: string): boolean {
+        if (!this.pendingSendMultisigTX) return false
+        else {
+            if (!this.signedDepositID() || this.signedDepositID() === depositTxID) return false
+            else return true
+        }
+    }
+    get isMultiSig(): boolean {
+        let wallet: WalletType = this.$store.state.activeWallet
+        return wallet.type === 'multisig'
+    }
+
+    get depositOffer(): DepositOffer | undefined {
+        return this.$store.getters['Platform/depositOffer'](this.reward.deposit.depositOfferID)
+    }
+
+    get rewardTitle() {
+        return this.depositOffer
+            ? Buffer.from(this.depositOffer.memo.replace('0x', ''), 'hex').toString()
+            : 'Unknown'
+    }
+
+    get startDate() {
+        const startDate = new Date(parseInt(this.reward.deposit.start.toString()) * 1000)
+
+        return startDate.toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            second: 'numeric',
+        })
+    }
+
+    get endDate() {
+        const endDate = new Date(
+            (this.reward.deposit.start.toNumber() + this.reward.deposit.duration) * 1000
+        )
+
+        return endDate.toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            second: 'numeric',
+        })
+    }
+
+    get rewardPercent() {
+        if (!this.depositOffer) return 0
+
+        const interestRateBase = 365 * 24 * 60 * 60
+        const interestRateDenominator = 1000000 * interestRateBase
+
+        return (
+            (this.depositOffer.interestRateNominator.toNumber() * interestRateBase * 100) /
+            interestRateDenominator
+        )
+    }
+
+    get minLock() {
+        return this.depositOffer?.minAmount ?? ZeroBN
+    }
+
+    get ava_asset(): AvaAsset | null {
+        let ava = this.$store.getters['Assets/AssetAVA']
+        return ava
+    }
+
+    get nativeAssetSymbol(): string {
+        return this.ava_asset?.symbol ?? ''
+    }
+
+    get isClaimDisabled() {
+        return this.reward.amountToClaim.isZero()
+    }
+
+    cleanAvaxBN(val: BN): string {
+        return cleanAvaxBN(val)
+    }
+
+    openModal() {
+        this.disclamer = false
+        this.$refs.modal_claim_reward.open()
+    }
+}
+</script>
+<style scoped lang="scss">
+@use '../../../styles/abstracts/mixins';
+@use '../../../styles/main';
+
+.offer_row {
+    display: flex;
+    flex-direction: column;
+    border-radius: var(--border-radius-sm);
+    overflow: hidden;
+    font-size: 14px;
+    background-color: var(--bg-light);
+    padding: 1rem;
+}
+
+.offer_title {
+    margin-bottom: 1rem;
+}
+
+.offer_detail {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 1.25rem;
+    .offer_detail_left {
+        border-right: 2px solid var(--bg-wallet-light);
+    }
+}
+
+label {
+    color: var(--primary-color-light) !important;
+}
+
+.claim_button {
+    border-radius: var(--border-radius-sm);
+    padding: 8px 30px;
+    margin-left: auto;
+    &[disabled] {
+        background-color: var(--primary-color) !important;
+    }
+}
+
+.offer_row {
+    display: flex;
+    flex-direction: column;
+    border-radius: var(--border-radius-sm);
+    overflow: hidden;
+    font-size: 14px;
+    background-color: var(--bg-light);
+    padding: 1rem;
+}
+
+.offer_title {
+    margin-bottom: 1rem;
+}
+
+.offer_detail {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 1.25rem;
+    .offer_detail_left {
+        border-right: 2px solid var(--bg-wallet-light);
+    }
+}
+
+.node_id {
+    word-break: break-all;
+}
+
+.top_bar {
+    height: max-content;
+    position: relative;
+    padding: 2px 8px;
+    border-bottom: 2px solid var(--bg-wallet-light);
+}
+.reward_row {
+    border-radius: var(--border-radius-sm);
+    overflow: hidden;
+    font-size: 14px;
+    //border: 2px solid var(--bg-light);
+    background-color: var(--bg-light);
+}
+
+.data_row {
+    grid-column: 1/3;
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    align-items: center;
+}
+
+.date {
+    z-index: 1;
+}
+.reward_bar {
+    background-color: var(--success);
+    position: absolute;
+    opacity: 0.5;
+    height: 100%;
+    left: 0;
+    top: 0;
+    z-index: 0;
+}
+
+.stake_info {
+    padding: 6px 12px;
+    display: grid;
+    column-gap: 14px;
+    grid-template-columns: 2fr 1fr 1fr;
+    /*justify-content: space-between;*/
+    /*text-align: right;*/
+    text-align: left;
+
+    > div {
+        align-self: baseline;
+    }
+}
+
+.v-btn {
+    margin-top: 0.5rem;
+}
+
+.bordered_button {
+    border-width: 1px;
+    border-style: solid;
+    border-radius: var(--border-radius-lg);
+    padding: 8px 24px;
+    border-color: var(--primary-btn-border-color);
+    color: var(--primary-btn-border-color);
+    background-color: transparent !important;
+    &:hover {
+        opacity: 0.6;
+    }
+    &[disabled] {
+        background: var(--bg-light);
+        border: var(--primary-border);
+        color: var(--primary-color-light);
+        border: var(--primary-border);
+        opacity: 0.3;
+        cursor: not-allowed;
+    }
+}
+
+label {
+    color: var(--primary-color-light) !important;
+}
+
+.claim_button {
+    border-radius: var(--border-radius-sm);
+    width: min-content;
+    padding: 8px 30px;
+    // margin-left: auto;
+    &[disabled] {
+        background-color: var(--primary-color) !important;
+    }
+}
+
+.button_group {
+    display: flex;
+    margin-left: auto;
+    gap: 0.5rem;
+    justify-content: end;
+}
+
+.err {
+    text-align: left;
+    color: var(--error);
+    font-size: 0.8rem;
+    margin-top: 10px;
+}
+
+@include main.mobile-device {
+    .offer_detail {
+        grid-template-columns: 1fr;
+        grid-gap: 0.5rem;
+        .offer_detail_left {
+            border-right: none;
+        }
+    }
+}
+
+@include main.mobile-device {
+    .stake_info {
+        grid-column: 1/3;
+        border-left: none;
+        border-top: 3px solid var(--bg);
+
+        > div:first-of-type {
+            text-align: left;
+        }
+    }
+}
+@include mixins.mobile-device {
+    .offer_detail {
+        grid-template-columns: 1fr;
+        grid-gap: 0.5rem;
+        .offer_detail_left {
+            border-right: none;
+        }
+    }
+}
+</style>

--- a/src/components/wallet/earn/ModalClaimDepositReward.vue
+++ b/src/components/wallet/earn/ModalClaimDepositReward.vue
@@ -178,7 +178,7 @@ export default class ModalClaimDepositReward extends Vue {
                 wallet,
                 this.depositTxID,
                 rewardOwner,
-                this.amt,
+                this.amount,
                 this.validatorClaim
             )
                 .then(async (value) => {
@@ -194,7 +194,7 @@ export default class ModalClaimDepositReward extends Vue {
                         return this.updateMultisigTxDetails()
                     }
 
-                    this.confiremedClaimedAmount = this.formattedAmount(this.amt)
+                    this.confiremedClaimedAmount = this.formattedAmount(this.amount)
                     this.updateBalance()
                     this.$store.dispatch('Platform/updateActiveDepositOffer')
                     this.updateMultisigTxDetails()
@@ -255,7 +255,7 @@ export default class ModalClaimDepositReward extends Vue {
 
             const amount = claimAmounts[0].getAmount()
             this.confiremedClaimedAmount = bnToBig(new BN(amount), 9)?.toLocaleString()
-        } else this.confiremedClaimedAmount = this.formattedAmount(this.amt)
+        } else this.confiremedClaimedAmount = this.formattedAmount(this.amount)
     }
 }
 </script>

--- a/src/components/wallet/earn/ModalDepositFunds.vue
+++ b/src/components/wallet/earn/ModalDepositFunds.vue
@@ -1,0 +1,675 @@
+<template>
+    <div>
+        <modal ref="modal" :title="title">
+            <div class="modal__body">
+                <div class="offer_row">
+                    <div class="offer_detail">
+                        <div class="progress">
+                            <label>{{ $t('earn.rewards.offer.pool_size') }}:</label>
+                            <span>
+                                <span class="success" :style="'width:' + progress"></span>
+                            </span>
+                            {{ progressText }}
+                        </div>
+                        <div class="offer_detail_left">
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.pool_start') }}:</label>
+                                <p class="reward">{{ formatDate(offer.start) }}</p>
+                            </div>
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.pool_end') }}:</label>
+                                <p class="reward">{{ formatDate(offer.end) }}</p>
+                            </div>
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.min_deposit') }}:</label>
+                                <p class="reward">{{ cleanAvaxBN(offer.minAmount) }} CAM</p>
+                            </div>
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.reward') }}:</label>
+                                <p class="reward">{{ rewardPercent }} %</p>
+                            </div>
+                        </div>
+                        <div class="offer_detail_right">
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.min_duration') }}:</label>
+                                <p class="reward">
+                                    {{ formatDuration(offer.minDuration) }}
+                                </p>
+                            </div>
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.max_duration') }}:</label>
+                                <p class="reward">
+                                    {{ formatDuration(offer.maxDuration) }}
+                                </p>
+                            </div>
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.unlock_duration') }}:</label>
+                                <p class="reward">
+                                    {{ formatDuration(offer.unlockPeriodDuration) }}
+                                </p>
+                            </div>
+                            <div>
+                                <label>{{ $t('earn.rewards.offer.no_reward_duration') }}:</label>
+                                <p class="reward">
+                                    {{ formatDuration(offer.noRewardsPeriodDuration) }}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <template>
+                    <div>
+                        <form class="deposit_row">
+                            <div class="deposit_inputs">
+                                <label>Deposit duration</label>
+                                <DateForm
+                                    v-if="!pendingDepositTX"
+                                    @change_end="setEndDate"
+                                    :maxEndDate="maxEndDate"
+                                    :minDurationMs="minDuration"
+                                    :maxDurationMs="maxDuration"
+                                    :defaultDurationMs="maxDuration"
+                                ></DateForm>
+                                <!-- <span v-if="rewardOwner">{{ rewardOwner }}</span> -->
+                                <span v-if="!pendingTxduration" class="deposit_duration">
+                                    {{ formatDuration(duration) }}
+                                </span>
+                                <span v-else class="deposit_duration">
+                                    {{ formatDuration(pendingTxduration) }}
+                                </span>
+                                <label style="margin-top: 16px">Reward Owner</label>
+                                <CamInput
+                                    :placeholder="`Rewrad Owner`"
+                                    v-model="rewardOwner"
+                                    class="reward-input"
+                                />
+                                <!-- <label style="margin-top: 16px">Deposit Owner</label>
+                                <CamInput
+                                    :placeholder="`Deposit Owner`"
+                                    v-model="depositOwner"
+                                    class="reward-input"
+                                /> -->
+                                <label style="margin-top: 16px">
+                                    {{ $t('earn.rewards.active_earning.deposit_amount') }}
+                                </label>
+                                <AvaxInput
+                                    v-if="pendingTxamount"
+                                    :max="maxDepositAmount"
+                                    v-model="amt"
+                                    :initial="pendingTxamount * 1000000000"
+                                    :readonly="pendingDepositTX"
+                                ></AvaxInput>
+                                <AvaxInput v-else :max="maxDepositAmount" v-model="amt"></AvaxInput>
+                                <Alert
+                                    v-if="pendingDepositTX"
+                                    variant="info"
+                                    style="margin-top: 16px"
+                                >
+                                    {{
+                                        $t('earn.validate.pending_multisig.threshold', {
+                                            value: sigValue,
+                                            threshold: pendingDepositTX?.tx.threshold,
+                                        })
+                                    }}
+                                </Alert>
+                                <Alert style="margin-top: 16px" v-if="SignStatus" variant="info">
+                                    {{ $t('earn.validate.pending_multisig.already_signed') }}
+                                </Alert>
+                            </div>
+                            <div class="submit_box">
+                                <template v-if="pendingDepositTX">
+                                    <div class="multi-sig__container">
+                                        <button
+                                            class="camino__negative--button"
+                                            @click.prevent="openAbortModal"
+                                        >
+                                            {{ $t('transfer.multisig.abort_transaction') }}
+                                        </button>
+                                        <button
+                                            v-if="canExecuteMultisigTx"
+                                            :class="['camino__primary--button']"
+                                            @click.prevent="issueMultisigTx"
+                                        >
+                                            {{ $t('transfer.multisig.execute_transaction') }}
+                                        </button>
+                                        <button
+                                            v-else
+                                            :class="[
+                                                'camino__primary--button',
+                                                { 'camino--button--disabled': disableSignButton },
+                                            ]"
+                                            @click.prevent="signMultisigTx"
+                                            :disabled="disableSignButton"
+                                        >
+                                            {{ $t('transfer.multisig.sign_transaction') }}
+                                        </button>
+                                    </div>
+                                </template>
+                                <template v-else>
+                                    <div class="button--container">
+                                        <button
+                                            class="camino__negative--button"
+                                            @click.prevent="cancelDeposit"
+                                        >
+                                            {{ $t('earn.validate.cancel') }}
+                                        </button>
+                                        <button
+                                            v-if="$listeners['selectOffer']"
+                                            :class="[
+                                                'camino__primary--button',
+                                                { 'camino--button--disabled': isDepositDisabled },
+                                            ]"
+                                            @click.prevent="submitDeposit"
+                                            :disabled="isDepositDisabled"
+                                        >
+                                            {{ $t('earn.rewards.offer.deposit') }}
+                                        </button>
+                                    </div>
+                                    <Alert variant="warning">
+                                        Creating this depositOffer will incurr a fee of
+                                        {{ feeAmt }} {{ nativeAssetSymbol }}
+                                    </Alert>
+                                </template>
+                            </div>
+                        </form>
+                    </div>
+                </template>
+            </div>
+        </modal>
+
+        <ModalAbortSigning
+            ref="modal_abort_signing"
+            :title="$t('transfer.multisig.abort_transaction')"
+            :modalText="$t('earn.rewards.abort_modal.message')"
+            @cancelTx="cancelMultisigTx"
+        />
+    </div>
+</template>
+<script lang="ts">
+import Alert from '@/components/Alert.vue'
+import AvaxInput from '@/components/misc/AvaxInput.vue'
+import { MINUTE_MS } from '@/constants'
+import { cleanAvaxBN, formatDuration } from '@/helpers/helper'
+import { WalletHelper } from '@/helpers/wallet_helper'
+import AvaAsset from '@/js/AvaAsset'
+import { MultisigWallet } from '@/js/wallets/MultisigWallet'
+import { WalletType } from '@/js/wallets/types'
+import { BN } from '@c4tplatform/caminojs'
+import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm'
+import { SignatureError, ZeroBN } from '@c4tplatform/caminojs/dist/common'
+import 'reflect-metadata'
+import { Component, Prop, Vue } from 'vue-property-decorator'
+import Modal from '../../modals/Modal.vue'
+
+import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
+
+import { ava, bintools } from '@/AVA'
+import CamInput from '@/components/CamInput.vue'
+import ModalAbortSigning from '@/components/wallet/earn/ModalAbortSigning.vue'
+import { Buffer } from '@c4tplatform/caminojs/dist'
+import { DepositTx, UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
+import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
+import DateForm from './DateForm.vue'
+
+@Component({
+    components: {
+        Modal,
+        DateForm,
+        AvaxInput,
+        ModalAbortSigning,
+        Alert,
+        CamInput,
+    },
+})
+export default class ModalDepositFunds extends Vue {
+    @Prop() offer!: DepositOffer
+    @Prop() title!: string
+    @Prop() error!: boolean
+    @Prop() warning!: boolean
+    @Prop() isDepositDisabled!: boolean
+    @Prop() maxDepositAmount!: BN
+    // @ts-ignore
+    helpers = this.globalHelper()
+    amt: BN = ZeroBN
+    ini: BN = new BN(5000000000)
+    endDate: string = ''
+    rewardOwner: string = ''
+    depositOwner: string = ''
+
+    $refs!: {
+        modal: Modal
+        modal_abort_signing: ModalAbortSigning
+    }
+    get activeWallet(): MultisigWallet {
+        return this.$store.state.activeWallet
+    }
+    get pendingDepositTX(): SignavaultTx | undefined {
+        return this.$store.getters['Signavault/transactions'].find(
+            (item: SignavaultTx) =>
+                item?.tx?.alias === this.$store.state.activeWallet?.getStaticAddress('P') &&
+                WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx) === 'DepositTx'
+        )
+    }
+    get pendingOfferID(): string | undefined {
+        if (this.pendingDepositTX) {
+            let unsignedTx = new UnsignedTx()
+            unsignedTx.fromBuffer(Buffer.from(this.pendingDepositTX.tx?.unsignedTx, 'hex'))
+            const utx = unsignedTx.getTransaction() as DepositTx
+            return bintools.cb58Encode(utx.getDepositOfferID())
+        }
+        return undefined
+    }
+    get pendingTxduration() {
+        if (this.pendingDepositTX) {
+            let unsignedTx = new UnsignedTx()
+            unsignedTx.fromBuffer(Buffer.from(this.pendingDepositTX.tx?.unsignedTx, 'hex'))
+            const utx = unsignedTx.getTransaction() as DepositTx
+            return parseInt(bintools.fromBufferToBN(utx.getDepositDuration()).toString())
+        }
+        return undefined
+    }
+    get pendingTxamount() {
+        if (this.pendingDepositTX) {
+            let unsignedTx = new UnsignedTx()
+            unsignedTx.fromBuffer(Buffer.from(this.pendingDepositTX.tx?.unsignedTx, 'hex'))
+            return WalletHelper.getTotalAmountFromUtxTest(unsignedTx)
+        }
+        return undefined
+    }
+    get txOwners() {
+        return this.pendingDepositTX?.tx?.owners ?? []
+    }
+    // get rewardOwner() {
+    //     if (this.pendingDepositTX) {
+    //         let unsignedTx = new UnsignedTx()
+    //         unsignedTx.fromBuffer(Buffer.from(this.pendingDepositTX.tx?.unsignedTx, 'hex'))
+    //         const utx = unsignedTx.getTransaction() as DepositTx
+    //         return bintools.addressToString(
+    //             ava.getHRP(),
+    //             'P',
+    //             utx.getRewardsOwner().getAddresses()[0]
+    //         )
+    //     }
+    //     return undefined
+    // }
+    get sigValue() {
+        return this.pendingDepositTX?.tx.owners?.filter((owner) => !!owner.signature)?.length
+    }
+    get SignStatus(): boolean {
+        let isSigned = false
+        this.txOwners.forEach((owner) => {
+            if (
+                this.activeWallet.wallets.find((w) => w?.getAllAddressesP()?.[0] === owner.address)
+            ) {
+                if (owner.signature) isSigned = true
+            }
+        })
+        return isSigned
+    }
+    get canExecuteMultisigTx(): boolean {
+        let signers = 0
+        let threshold = this.pendingDepositTX?.tx?.threshold
+        this.txOwners.forEach((owner) => {
+            if (owner.signature) signers++
+        })
+        if (threshold) return signers >= threshold
+        return false
+    }
+    get disableSignButton(): boolean {
+        let isSigned = false
+        this.txOwners.forEach((owner) => {
+            if (
+                this.activeWallet.wallets.find((w) => w?.getAllAddressesP()?.[0] === owner.address)
+            ) {
+                if (owner.signature) isSigned = true
+            }
+        })
+        return isSigned
+    }
+    get maxEndDate() {
+        return this.offer.end.toNumber() * 1000
+    }
+
+    get minDuration() {
+        return this.offer.minDuration * 1000
+    }
+
+    get maxDuration() {
+        return this.offer.maxDuration * 1000 - 15 * MINUTE_MS
+    }
+    get rewardPercent() {
+        const interestRateBase = 365 * 24 * 60 * 60
+        const interestRateDenominator = 1000000 * interestRateBase
+
+        return (
+            (this.offer.interestRateNominator.toNumber() * interestRateBase * 100) /
+            interestRateDenominator
+        )
+    }
+    get progressText(): string {
+        const amt = this.amountLimit
+        return amt.amount.isZero()
+            ? 'No Limit'
+            : this.progress + '(' + cleanAvaxBN(amt.amount) + this.nativeAssetSymbol + ')'
+    }
+    get amountLimit(): { nominator: BN; amount: BN } {
+        return this.offer.upgradeVersion === 0 || !this.offer.totalMaxAmount.isZero()
+            ? { nominator: this.offer.depositedAmount, amount: this.offer.totalMaxAmount }
+            : { nominator: this.offer.rewardedAmount, amount: this.offer.totalMaxRewardAmount }
+    }
+    get ava_asset(): AvaAsset | null {
+        let ava = this.$store.getters['Assets/AssetAVA']
+        return ava
+    }
+    get nativeAssetSymbol(): string {
+        return this.ava_asset?.symbol ?? ''
+    }
+
+    get progress(): string {
+        const amt = this.amountLimit
+        return amt.amount.isZero()
+            ? '0px'
+            : amt.nominator.div(amt.amount).mul(new BN(100)).toString() + '%'
+    }
+
+    get duration() {
+        const endDate = new Date(this.endDate).getTime()
+        return Math.floor((endDate - Date.now()) / 1000)
+    }
+
+    get feeAmt(): string {
+        return this.formattedAmount(ava.PChain().getTxFee())
+    }
+    formattedAmount(val: BN): string {
+        return `${(Number(val.toString()) / Number(ONEAVAX.toString())).toLocaleString()}`
+    }
+    async submitDeposit(): Promise<void> {
+        const wallet: WalletType = this.$store.state.activeWallet
+        try {
+            const result = await WalletHelper.buildDepositTx(
+                wallet,
+                this.offer.id,
+                this.duration,
+                this.amt,
+                this.$store.getters['Platform/isDepositOfferRestricted'](this.offer.id),
+                this.offer.ownerAddress,
+                this.rewardOwner,
+                this.depositOwner
+            )
+            let { dispatchNotification } = this.helpers
+            this.rewardOwner = ''
+            await this.$store.dispatch('Assets/updateUTXOs')
+            await this.$store.dispatch('Platform/update')
+            dispatchNotification({
+                message: `Deposit Successful (TX: ${result})`,
+                type: 'success',
+            })
+            if (!(wallet instanceof MultisigWallet)) this.cancelDeposit()
+        } catch (error) {
+            if (error instanceof SignatureError) {
+                this.$store.dispatch('Assets/updateUTXOs')
+                this.$store.dispatch('Signavault/updateTransaction').then(() => {
+                    this.$store.dispatch('updateBalances')
+                    this.helpers.dispatchNotification({
+                        message: this.$t('notifications.transfer_success_msg'),
+                        type: 'success',
+                    })
+                })
+            }
+        }
+    }
+    async signMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.debug('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingDepositTX) return console.debug('MultiSigTx::sign: Invalid Tx')
+        try {
+            await wallet.addSignatures(this.pendingDepositTX?.tx)
+            this.helpers.dispatchNotification({
+                message: 'Your signature saved successfully!',
+                type: 'success',
+            })
+            this.$store.dispatch('Signavault/updateTransaction')
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: 'Your signature is not saved.',
+                type: 'error',
+            })
+        }
+    }
+    async issueMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.log('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingDepositTX) return console.log('MultiSigTx::sign: Invalid Tx')
+        try {
+            let txID = await wallet.issueExternal(this.pendingDepositTX?.tx)
+            let { dispatchNotification } = this.helpers
+            await this.$store.dispatch('Assets/updateUTXOs')
+            await this.$store.dispatch('Platform/update')
+            dispatchNotification({
+                message: `Deposit Successful (TX: ${txID})`,
+                type: 'success',
+            })
+            await this.$store.dispatch('Signavault/updateTransaction')
+            this.cancelDeposit()
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: this.$t('notifications.execute_multisig_transaction_error'),
+                type: 'error',
+            })
+        }
+    }
+    async cancelMultisigTx() {
+        try {
+            const wallet = this.activeWallet as MultisigWallet
+            if (this.pendingDepositTX) {
+                await wallet.cancelExternal(this.pendingDepositTX?.tx)
+                this.helpers.dispatchNotification({
+                    message: this.$t('transfer.multisig.transaction_aborted'),
+                    type: 'success',
+                })
+                await this.$store.dispatch('Assets/updateUTXOs')
+                await this.$store.dispatch('Signavault/updateTransaction')
+                this.cancelDeposit()
+            }
+        } catch (err) {
+            this.helpers.dispatchNotification({
+                message: this.$t('transfer.multisig.cancel_transaction_failed'),
+                type: 'error',
+            })
+        }
+    }
+    cancelDeposit() {
+        this.$emit('closeDepositFundsModal')
+    }
+    formatDate(date: BN): string {
+        const jsDate = new Date(date.toNumber() * 1000)
+        return jsDate.toLocaleString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: 'numeric',
+            second: 'numeric',
+        })
+    }
+    formatDuration(dur: number): string {
+        return formatDuration(dur)
+    }
+    cleanAvaxBN(val: BN): string {
+        return cleanAvaxBN(val)
+    }
+    close() {
+        this.$refs.modal.close()
+    }
+
+    open() {
+        this.$refs.modal.open()
+    }
+    setEndDate(val: string) {
+        this.endDate = val
+    }
+    openAbortModal() {
+        this.$refs.modal_abort_signing.open()
+    }
+}
+</script>
+<style scoped lang="scss">
+@use '../../../styles/abstracts/mixins';
+.reward-input {
+    height: 35px !important;
+    width: 100%;
+    input {
+        width: 100%;
+        padding: 6px 10px !important;
+        border-radius: 6px !important;
+        height: 35px !important;
+    }
+}
+.modal__body {
+    padding: 30px 22px;
+    text-align: center;
+    width: 600px;
+    overflow-x: hidden;
+}
+.offer_row {
+    display: flex;
+    flex-direction: column;
+    border-radius: var(--border-radius-sm);
+    overflow: hidden;
+    font-size: 14px;
+    background-color: var(--bg-light);
+    padding: 1rem;
+}
+
+.offer_title {
+    margin-bottom: 1rem;
+}
+.button--container {
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    gap: 16px;
+}
+.progress {
+    grid-column: span 2;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-gap: 1.25rem;
+    > span {
+        margin-top: auto;
+        margin-bottom: auto;
+        height: 4px;
+        background-color: var(--bg);
+        display: inline-block;
+    }
+    .success {
+        height: 100%;
+        background-color: var(--color-success);
+        display: block;
+    }
+}
+
+.offer_detail {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 4px 1.25rem;
+    .offer_detail_left {
+        border-right: 2px solid var(--bg-wallet-light);
+    }
+    .offer_detail_left,
+    .offer_detail_right {
+        div {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+        }
+    }
+}
+
+label {
+    color: var(--primary-color-light) !important;
+    font-size: 13px;
+}
+
+.claim_button {
+    border-radius: var(--border-radius-sm);
+    padding: 8px 30px;
+    margin-left: auto;
+    &[disabled] {
+        background-color: var(--primary-color) !important;
+    }
+}
+
+.deposit_row {
+    display: flex;
+    flex-direction: column;
+    border-radius: var(--border-radius-sm);
+    margin-top: 16px;
+    overflow: hidden;
+    font-size: 14px;
+    padding: 1rem;
+}
+
+form {
+    display: grid;
+    grid-template-columns: 1fr 340px;
+    column-gap: 90px;
+
+    .dates_form {
+        margin-top: 4px;
+        margin-bottom: 4px;
+    }
+    p {
+        margin-bottom: 12px !important;
+    }
+}
+
+.deposit_inputs {
+    margin-bottom: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+}
+
+.deposit_duration {
+    font-size: 13px;
+    padding-right: 12px;
+    float: right;
+}
+.multi-sig__container {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+}
+.submit_box {
+    margin-top: auto;
+    margin-left: auto;
+    display: flex;
+    gap: 16px;
+    flex-direction: column;
+    .v-btn {
+        margin-top: 14px;
+        margin-right: 10px;
+    }
+}
+
+.deposit_button {
+    border-radius: var(--border-radius-sm);
+    padding: 8px 30px;
+    margin-left: auto;
+    &[disabled] {
+        background-color: var(--primary-color) !important;
+    }
+}
+@include mixins.mobile-device {
+    .offer_detail {
+        grid-template-columns: 1fr;
+        grid-gap: 0.5rem;
+        .offer_detail_left {
+            border-right: none;
+        }
+    }
+}
+</style>

--- a/src/components/wallet/earn/ModalDepositFunds.vue
+++ b/src/components/wallet/earn/ModalDepositFunds.vue
@@ -415,6 +415,12 @@ export default class ModalDepositFunds extends Vue {
                         type: 'success',
                     })
                 })
+            } else {
+                let err = error as Error
+                this.helpers.dispatchNotification({
+                    message: err.message,
+                    type: 'error',
+                })
             }
         }
     }

--- a/src/components/wallet/earn/UserRewards.vue
+++ b/src/components/wallet/earn/UserRewards.vue
@@ -1,203 +1,56 @@
 <template>
-    <div>
-        <div class="user_offers" v-if="activeOffers.length > 0">
-            <UserRewardCard
-                v-for="(v, i) in activeOffers"
-                :key="i"
-                :depositTxID="v.depositTxID"
-                :title="v.memo"
-                :start="v.start"
-                :duration="v.lockDuration"
-                :minLock="v.minAmount"
-                :rewards="v.interestRateNominator"
-                :lockedAmount="v.amount"
-                :alreadyClaimed="v.claimedRewardAmount"
-                :pendingRewards="v.pendingRewards"
-                :rewardOwner="v.rewardOwner"
-                :signatureStatus="signatureStatus(v.depositTxID)"
-                :alreadySigned="alreadySigned(v.depositTxID)"
-                :disallowedClaim="disallowedClaim(v.depositTxID)"
-                :canExecuteMultisigTx="canExecuteMultisigTx(v.depositTxID)"
-                class="reward_card"
-            />
+    <div v-if="hasRewards">
+        <div class="claimables">
+            <ClaimableRewardCard
+                v-for="(v, i) in platformRewards.treasuryRewards"
+                :key="'c' + i"
+                :reward="v"
+            ></ClaimableRewardCard>
         </div>
-        <div v-else class="empty">No Active Earning</div>
+        <div class="user_offers">
+            <DepositRewardCard
+                v-for="(v, i) in platformRewards.depositRewards"
+                :key="'u' + i"
+                :reward="v"
+                class="reward_card"
+            ></DepositRewardCard>
+        </div>
     </div>
+    <div v-else class="empty">No Active Earning</div>
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Component, Prop, Vue } from 'vue-property-decorator'
-import { AvaWalletCore } from '../../../js/wallets/types'
-import { DelegatorRaw, ValidatorRaw } from '@/components/misc/ValidatorList/types'
-import UserRewardRow from '@/components/wallet/earn/UserRewardRow.vue'
-import UserRewardCard from '@/components/wallet/earn/UserRewardCard.vue'
-import { bnToBig } from '@/helpers/helper'
-import Big from 'big.js'
-import { BN } from '@c4tplatform/caminojs/dist'
-import { bintools } from '@/AVA'
-import { WalletType } from '@/js/wallets/types'
-import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
-import { WalletHelper } from '@/helpers/wallet_helper'
-import { Buffer } from '@c4tplatform/caminojs/dist'
-import { UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
-import { ModelMultisigTxOwner } from '@c4tplatform/signavaultjs'
-import { MultisigWallet } from '@/js/wallets/MultisigWallet'
-import { ActiveDeposit } from '@/components/misc/ValidatorList/types'
-import { ClaimTx } from '@c4tplatform/caminojs/dist/apis/platformvm/claimtx'
+import { Component, Vue } from 'vue-property-decorator'
+
+import ClaimableRewardCard from '@/components/wallet/earn/ClaimableRewardCard.vue'
+import DepositRewardCard from '@/components/wallet/earn/DepositRewardCard.vue'
+import { PlatformRewards } from '@/store/modules/platform/types'
 
 @Component({
     components: {
-        UserRewardRow,
-        UserRewardCard,
+        ClaimableRewardCard,
+        DepositRewardCard,
     },
 })
 export default class UserRewards extends Vue {
-    @Prop() loadingRefreshDepositRewards!: boolean
-
-    get activeOffers(): ActiveDeposit[] {
-        return this.$store.state.Platform.activeDepositOffer
+    get platformRewards(): PlatformRewards {
+        return this.$store.state.Platform.rewards
     }
 
-    get userAddresses() {
-        let wallet: AvaWalletCore = this.$store.state.activeWallet
-        if (!wallet) return []
-
-        return wallet.getAllAddressesP()
-    }
-
-    get validators(): ValidatorRaw[] {
-        let validators: ValidatorRaw[] = this.$store.state.Platform.validators
-
-        return this.cleanList(validators) as ValidatorRaw[]
-    }
-
-    get totLength() {
-        return this.validators?.length
-    }
-
-    get totalReward() {
-        let vals = this.validators?.reduce((acc, val: ValidatorRaw) => {
-            return acc.add(new BN(val.potentialReward))
-        }, new BN(0))
-
-        return vals
-    }
-
-    get totalRewardBig(): Big {
-        return bnToBig(this.totalReward, 9)
+    get hasRewards(): boolean {
+        return (
+            this.platformRewards.depositRewards.length > 0 ||
+            this.platformRewards.treasuryRewards.length > 0
+        )
     }
 
     get nativeAssetSymbol(): string {
         return this.$store.getters['Assets/AssetAVA']?.symbol ?? ''
     }
-
-    cleanList(list: ValidatorRaw[] | DelegatorRaw[]) {
-        let res = list?.filter((val) => {
-            let rewardAddrs = val.rewardOwner.addresses
-            let filtered = rewardAddrs.filter((addr) => {
-                return this.userAddresses.includes(addr)
-            })
-            return filtered.length > 0
-        })
-
-        res?.sort((a, b) => {
-            let startA = parseInt(a.startTime)
-            let startB = parseInt(b.startTime)
-            return startA - startB
-        })
-        return res
-    }
-
-    get activeWallet(): WalletType {
-        return this.$store.state.activeWallet
-    }
-
-    alreadySigned(depositTxID: string): boolean {
-        const txOwners = this.txOwners(depositTxID)
-        if (!txOwners) return false
-
-        const walletAddresses = (this.activeWallet as MultisigWallet)?.wallets?.map(
-            (w) => w?.getAllAddressesP()?.[0]
-        )
-        if (!walletAddresses) return false
-
-        const isSigned = txOwners.some((owner) => {
-            if (!owner) return false
-            const isOwnerSigned = owner.signature && walletAddresses.includes(owner.address)
-            return isOwnerSigned
-        })
-
-        return isSigned
-    }
-
-    pendingSendMultisigTX(): SignavaultTx | undefined {
-        const tx: SignavaultTx = this.$store.getters['Signavault/transactions'].find(
-            (item: any) =>
-                item?.tx?.alias === this.activeWallet.getStaticAddress('P') &&
-                WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx) === 'ClaimTx'
-        )
-
-        if (!tx) return undefined
-        return tx
-    }
-
-    signedDepositID() {
-        const tx = this.pendingSendMultisigTX()
-
-        if (!tx) return undefined
-
-        const unsignedTx = new UnsignedTx()
-        unsignedTx.fromBuffer(Buffer.from(tx.tx?.unsignedTx, 'hex'))
-        const utx = unsignedTx.getTransaction() as ClaimTx
-        const claimAmounts = utx.getClaimAmounts()
-
-        return bintools.cb58Encode(claimAmounts[0].getID())
-    }
-
-    getPendingMultisigTx(depositTxID: string): SignavaultTx | undefined {
-        const tx = this.pendingSendMultisigTX()
-        if (!tx) return undefined
-
-        const depositId = this.signedDepositID()
-        if (depositId === depositTxID) return tx
-        else return undefined
-    }
-
-    txOwners(depositTxID: string): ModelMultisigTxOwner[] | [] {
-        return this.getPendingMultisigTx(depositTxID)?.tx?.owners ?? []
-    }
-
-    canExecuteMultisigTx(depositTxID: string): boolean {
-        let signers = 0
-        let threshold = this.getPendingMultisigTx(depositTxID)?.tx?.threshold
-        const txOwners = this.txOwners(depositTxID)
-
-        txOwners.forEach((owner) => {
-            if (owner.signature) signers++
-        })
-        if (threshold) return signers >= threshold
-        return false
-    }
-
-    signatureStatus(depositTxID: string): number {
-        if (!this.getPendingMultisigTx(depositTxID)?.tx) return -1
-        else if (!this.canExecuteMultisigTx(depositTxID)) return 1
-        else if (this.canExecuteMultisigTx(depositTxID)) return 2
-
-        return -1
-    }
-
-    disallowedClaim(depositTxID: string): boolean {
-        if (!this.pendingSendMultisigTX) return false
-        else {
-            if (!this.signedDepositID() || this.signedDepositID() === depositTxID) return false
-            else return true
-        }
-    }
 }
 </script>
 <style scoped lang="scss">
-@use '../../../styles/main';
+@use '../../../styles/abstracts/mixins';
 .user_offers {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
@@ -205,22 +58,11 @@ export default class UserRewards extends Vue {
     grid-gap: 1rem;
 }
 
-h3 {
-    margin: 12px 0;
-    margin-top: 32px;
-    font-size: 2em;
-    color: var(--primary-color);
-    font-weight: normal;
+.claimables {
+    margin-bottom: 10px;
 }
 
-label {
-    margin-top: 6px;
-    color: var(--primary-color-light);
-    font-size: 14px;
-    margin-bottom: 3px;
-}
-
-@include main.medium-device {
+@include mixins.medium-device {
     .user_offers {
         display: grid;
         grid-template-rows: repeat(1, 1fr);
@@ -228,7 +70,7 @@ label {
         grid-gap: 1rem;
     }
 }
-@include main.mobile-device {
+@include mixins.mobile-device {
     .user_offers {
         display: grid;
         grid-template-rows: repeat(1, 1fr);

--- a/src/components/wallet/earn/mountCreateOfferForm.ts
+++ b/src/components/wallet/earn/mountCreateOfferForm.ts
@@ -1,0 +1,32 @@
+import router from '@/router'
+import store from '@/store'
+import Vue from 'vue'
+import VueMeta from 'vue-meta'
+
+import i18n from '@/plugins/i18n'
+import vuetify from '@/plugins/vuetify'
+import BootstrapVue from 'bootstrap-vue'
+import { Datetime } from 'vue-datetime'
+import 'vue-datetime/dist/vue-datetime.css'
+
+import DepositOffer from './DepositOffers.vue'
+
+Vue.use(VueMeta)
+Vue.use(BootstrapVue)
+Vue.component('datetime', Datetime)
+export const mountCreateOfferForm = (el: string, props?: { isSuite: boolean }) => {
+    const context = {
+        props: props,
+    }
+    const app = new Vue({
+        router,
+        store,
+        vuetify,
+        i18n,
+        data: {},
+        render: (createElement) => {
+            return createElement(DepositOffer, context)
+        },
+    })
+    app.$mount(el)
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,8 @@ export const HOUR_MS = MINUTE_MS * 60
 export const DAY_MS = HOUR_MS * 24
 export const CF_IPFS_BASE = 'https://cloudflare-ipfs.com/ipfs/'
 export const ZeroBN = new BN(0)
+export const OneBN = new BN(1)
+
 export type ChainIdType = 'X' | 'P' | 'C'
 export type CrossChainsC = 'X' | 'P'
 export type CrossChainsP = 'X' | 'C'

--- a/src/js/wallets/types.ts
+++ b/src/js/wallets/types.ts
@@ -108,7 +108,7 @@ export interface AvaWalletCore extends IAddressManager {
     estimateGas(to: string, amount: BN, token: Erc20Token): Promise<number>
 
     signX(unsignedTx: AVMUnsignedTx): Promise<AVMTx>
-    signP(unsignedTx: PlatformUnsignedTx): Promise<PlatformTx>
+    signP(unsignedTx: PlatformUnsignedTx, additionalSigners?: string[]): Promise<PlatformTx>
     signC(unsignedTx: EVMUnsignedTx): Promise<EVMTx>
     signEvm(tx: Transaction): Promise<Transaction>
     validate(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -508,6 +508,10 @@
                 "owner_address": "Owner Address (optional)",
                 "submit": "Create Offer"
             },
+            "errors": {
+                "title": "Credit Offre title must be at least 64 characters long.",
+                "min_amount": "Minimum amount must be at least {minAmount} {symbol}."
+            },
             "offer": {
                 "title": "Active Saving Pools",
                 "reward": "Reward",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -492,6 +492,36 @@
             "earn_now": {
                 "title": "Saving Pools"
             },
+            "create": {
+                "offer_start": "Offer Start",
+                "offer_end": "Offer End",
+                "interrest_rate": "Interrest rate ( *1 000 000 )",
+                "min_amount": "Min Amount",
+                "total_max_amount": "Total Max Amount",
+                "min_duration": "Minimum Duration (Sec)",
+                "max_duration": "Maximum Duration (Sec)",
+                "unlock_duration": "Unlock Duration (Sec)",
+                "no_rewards_duration": "No Rewards Duration (Sec)",
+                "memo": "Title",
+                "flags": "Flags (Blocked:1)",
+                "total_max_reward_amount": "Total Max Reward Amount",
+                "owner_address": "Owner Address (optional)",
+                "submit": "Create Offer"
+            },
+            "offer": {
+                "title": "Active Saving Pools",
+                "reward": "Reward",
+                "pool_size": "Pool Size",
+                "pool_start": "Pool Start",
+                "pool_end": "Pool End",
+                "min_deposit": "Minimum Deposit",
+                "min_duration": "Minimum Duration",
+                "max_duration": "Maximum Duration",
+                "unlock_duration": "Unlock Duration",
+                "no_reward_duration": "NoReward Duration",
+                "balance": "Available for Deposit",
+                "deposit": "Deposit Now"
+            },
             "active_earning": {
                 "title": "My Rewards",
                 "lock_start": "Lock Start",
@@ -510,7 +540,11 @@
                 "signed": "Signed {nbSigners}/{threshold}",
                 "confirm_claim": "Confirm claim",
                 "pending_claim": "Confirm claiming rewards {nbSigners}/{threshold}",
-                "execute_claim": "Execute claim"
+                "execute_claim": "Execute claim",
+                "deposit_start": "Deposit Start",
+                "deposit_end": "Deposit End",
+                "deposit_amount": "Deposit Amount",
+                "deposited_amount": "Deposited Amount"
             },
             "claim_modal": {
                 "are_you_sure": "Are you sure you want to claim {amount} {symbol} rewards?",

--- a/src/signavault_api.ts
+++ b/src/signavault_api.ts
@@ -1,12 +1,12 @@
-import { ava } from '@/AVA'
 import { Buffer } from '@c4tplatform/caminojs/dist'
+import { SignerKeyPair } from '@c4tplatform/caminojs/dist/common'
 import {
     Configuration,
+    DepositOfferApi,
     ModelMultisigTx,
     ModelMultisigTxOwner,
     MultisigApi,
 } from '@c4tplatform/signavaultjs'
-import { SignerKeyPair } from '@c4tplatform/caminojs/dist/common'
 import createHash from 'create-hash'
 import store from './store/index'
 
@@ -34,6 +34,24 @@ function SignaVault(): MultisigApi {
     return new MultisigApi(config)
 }
 
+function SignaVaultDepositOfferApi(): DepositOfferApi {
+    let config = defaultConfig
+    const activeNetwork = store.state.network
+
+    const versioRegex = /\/v\d+$/
+    const signavaultUrl =
+        activeNetwork?.signavaultUrl && versioRegex.test(activeNetwork.signavaultUrl)
+            ? activeNetwork.signavaultUrl
+            : activeNetwork.signavaultUrl + defaultVersion
+
+    if (activeNetwork.signavaultUrl) {
+        config = new Configuration({
+            basePath: signavaultUrl,
+        })
+    }
+    return new DepositOfferApi(config)
+}
+
 async function SignaVaultTx(alias: string, signer: SignerKeyPair): Promise<ModelMultisigTx[]> {
     const sv = SignaVault()
 
@@ -52,5 +70,5 @@ async function SignaVaultTx(alias: string, signer: SignerKeyPair): Promise<Model
     return res.data
 }
 
+export { SignaVault, SignaVaultDepositOfferApi, SignaVaultTx }
 export type { ModelMultisigTx, ModelMultisigTxOwner }
-export { SignaVault, SignaVaultTx }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -462,6 +462,7 @@ export default new Vuex.Store({
                 dispatch('Accounts/updateKycStatus')
                 dispatch('updateBalances')
                 updateFilterAddresses()
+                dispatch('Platform/update')
                 dispatch('fetchMultiSigAliases', { disable: false })
             })
         },
@@ -595,13 +596,6 @@ export default new Vuex.Store({
                     dispatch('History/updateTransactionHistory')
                 }, 3000)
             }
-            if (options.msgType) {
-                dispatch('Notifications/add', {
-                    type: options.msgType,
-                    title: options.msgTitle,
-                    message: options.msgText,
-                })
-            }
         },
         updateBalances({ dispatch }) {
             dispatch('Assets/updateUTXOs').then(() =>
@@ -609,6 +603,7 @@ export default new Vuex.Store({
                     dispatch('History/updateTransactionHistory')
                 })
             )
+            dispatch('Platform/updateAddressStates')
         },
     },
 })

--- a/src/store/modules/network/network.ts
+++ b/src/store/modules/network/network.ts
@@ -169,7 +169,9 @@ const network_module: Module<NetworkState, RootState> = {
             }
 
             await dispatch('Assets/onNetworkChange', net, { root: true })
-            dispatch('Assets/updateUTXOs', null, { root: true })
+            dispatch('Assets/updateUTXOs', null, { root: true }).then(() => {
+                dispatch('Platform/update', null, { root: true })
+            })
             dispatch('Platform/update', null, { root: true })
             dispatch('updateTxFee')
             dispatch('Accounts/updateKycStatus', null, { root: true })

--- a/src/store/modules/platform/platform.ts
+++ b/src/store/modules/platform/platform.ts
@@ -1,50 +1,51 @@
 import { Module } from 'vuex'
+
+import { ava, bintools } from '@/AVA'
+import { OneBN, ZeroBN } from '@/constants'
 import { RootState } from '@/store/types'
-
-import { BN } from '@c4tplatform/caminojs/dist'
-import { ZeroBN } from '@/constants'
-import { ava } from '@/AVA'
-
 import {
     GetPendingValidatorsResponse,
     GetValidatorsResponse,
+    PlatformRewards,
     PlatformState,
-    ValidatorDelegatorDict,
-    ValidatorDelegatorPendingDict,
-    ValidatorListItem,
-} from '@/store/modules/platform/types'
-import {
-    DelegatorPendingRaw,
-    DelegatorRaw,
     ValidatorRaw,
-    ActiveDeposit,
-} from '@/components/misc/ValidatorList/types'
-import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
-import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm/interfaces'
+} from './types'
 
-const MINUTE_MS = 60000
-const HOUR_MS = MINUTE_MS * 60
-const DAY_MS = HOUR_MS * 24
+import { MultisigWallet } from '@/js/wallets/MultisigWallet'
+import { SignaVaultDepositOfferApi } from '@/signavault_api'
+import { BN, Buffer } from '@c4tplatform/caminojs/dist'
+import { AddressState } from '@c4tplatform/caminojs/dist/apis/platformvm'
+import { Claimable, OwnerParam } from '@c4tplatform/caminojs/dist/apis/platformvm/interfaces'
+import { SECP256k1KeyPair } from '@c4tplatform/caminojs/dist/common'
+import { ModelDepositOfferSig } from '@c4tplatform/signavaultjs'
+import createHash from 'create-hash'
 
 const platform_module: Module<PlatformState, RootState> = {
     namespaced: true,
     state: {
         validators: [],
         validatorsPending: [],
-        // delegators: [],
-        delegatorsPending: [],
         minStake: new BN(0),
         minStakeDelegation: new BN(0),
         currentSupply: new BN(1),
         depositOffers: [],
-        activeDepositOffer: [],
+        restrictedOffers: [],
+        rewards: {
+            treasuryRewards: [],
+            depositRewards: [],
+        },
+        addressStates: ZeroBN,
+        sunrisePhase: 0,
     },
     mutations: {
         setValidators(state, validators: ValidatorRaw[]) {
             state.validators = validators
         },
-        updateDepositOffers(state, results) {
-            state.depositOffers = results
+        setAddressStates(state, states: BN) {
+            state.addressStates = states
+        },
+        setSunrisePhase(state, phase: number) {
+            state.sunrisePhase = phase
         },
     },
     actions: {
@@ -58,220 +59,221 @@ const platform_module: Module<PlatformState, RootState> = {
         },
 
         async update({ dispatch }) {
-            dispatch('updateValidators')
             dispatch('updateCurrentSupply')
             dispatch('updateMinStakeAmount')
-            dispatch('updateAllDepositOffers')
-            dispatch('updateActiveDepositOffer')
+            dispatch('updateSunrisePhase')
+            dispatch('updateAddressStates')
+            dispatch('getRestrictedOffers')
+            dispatch('updateValidators').then(() =>
+                dispatch('updateAllDepositOffers').then(() => {
+                    dispatch('updateRewards')
+                })
+            )
         },
 
         async updateValidators({ dispatch }) {
-            dispatch('updateValidatorsCurrent')
-            dispatch('updateValidatorsPending')
+            const p1 = dispatch('updateValidatorsCurrent')
+            const p2 = dispatch('updateValidatorsPending')
+            await Promise.all([p1, p2])
         },
 
-        async updateValidatorsCurrent({ state, commit }) {
+        async updateValidatorsCurrent({ commit }) {
             let res = (await ava.PChain().getCurrentValidators()) as GetValidatorsResponse
             let validators = res.validators
 
             commit('setValidators', validators)
         },
 
-        async updateValidatorsPending({ state, commit }) {
+        async updateValidatorsPending({ state }) {
             let res = (await ava.PChain().getPendingValidators()) as GetPendingValidatorsResponse
             let validators = res.validators
-            let delegators = res.delegators
 
             //@ts-ignore
             state.validatorsPending = validators
-            state.delegatorsPending = delegators
         },
 
-        async updateAllDepositOffers({ state, commit }) {
-            const results = (await ava.PChain().getAllDepositOffers()) as DepositOffer[]
-
-            commit('updateDepositOffers', results)
+        async updateAllDepositOffers({ state }) {
+            const res = await ava.PChain().getAllDepositOffers()
+            res.sort((a, b) => {
+                if (!a.start.eq(b.start)) return a.start.lt(b.start) ? -1 : 1
+                return a.id < b.id ? -1 : 1
+            })
+            state.depositOffers = res
         },
-        async updateActiveDepositOffer({ state, commit, rootState }) {
-            try {
-                const wallet = rootState.activeWallet
-                const pAddressStrings = wallet?.getAllAddressesP() as string[] | string
 
-                if (!pAddressStrings) {
-                    state.activeDepositOffer = []
-                    return
-                }
-
-                const utxos = await ava.PChain().getUTXOs(pAddressStrings)
-                const lockedTxIDs = await utxos.utxos.getLockedTxIDs()
-                const activeDepositOffers = await ava.PChain().getDeposits(lockedTxIDs.depositIDs)
-
-                const activeOffers = [] as ActiveDeposit[]
-
-                for (const depositOffer of activeDepositOffers.deposits) {
-                    const matchingOffer = state.depositOffers.find(
-                        (o) => o.id === depositOffer.depositOfferID
-                    )
-
-                    if (matchingOffer) {
-                        const index = activeDepositOffers.deposits.indexOf(depositOffer)
-                        activeOffers.push({
-                            depositTxID: activeDepositOffers.deposits[index].depositTxID,
-                            memo: matchingOffer.memo,
-                            start: activeDepositOffers.deposits[index].start,
-                            lockDuration: activeDepositOffers.deposits[index].duration,
-                            minAmount: matchingOffer.minAmount,
-                            interestRateNominator: matchingOffer.interestRateNominator,
-                            amount: activeDepositOffers.deposits[index].amount,
-                            claimedRewardAmount:
-                                activeDepositOffers.deposits[index].claimedRewardAmount,
-                            pendingRewards: activeDepositOffers.availableRewards[index],
-                            rewardOwner: activeDepositOffers.deposits[index].rewardOwner,
-                        })
+        async updateRewards({ state, rootState, getters }) {
+            const newRewards: PlatformRewards = { treasuryRewards: [], depositRewards: [] }
+            const wallet = rootState.activeWallet
+            if (wallet) {
+                const lockedTxIDs = wallet.getPlatformUTXOSet().getLockedTxIDs()
+                const addresses = wallet.getAllAddressesP()
+                if (lockedTxIDs.depositIDs.length > 0) {
+                    try {
+                        const activeDepositOffers = await ava
+                            .PChain()
+                            .getDeposits(lockedTxIDs.depositIDs)
+                        activeDepositOffers.deposits.forEach((deposit, idx) =>
+                            newRewards.depositRewards.push({
+                                amountToClaim: activeDepositOffers.availableRewards[idx],
+                                deposit: deposit,
+                            })
+                        )
+                    } catch (e: unknown) {
+                        console.log(e)
                     }
                 }
+                // Since magellan is not ready we get treasury rewards
+                // by requesting the node with all single threshold owners
+                const owners = addresses.map(
+                    (a) => ({ locktime: '0', threshold: 1, addresses: [a] } as OwnerParam)
+                )
 
-                state.activeDepositOffer = activeOffers
-            } catch (error) {
-                state.activeDepositOffer = []
-                console.error(error)
+                let validatorFound = false
+                const pushReward = (c: Claimable, idx: number, v: boolean) => {
+                    if (v) validatorFound = true
+                    newRewards.treasuryRewards.push({
+                        type: v ? 'validator' : 'deposit',
+                        amountToClaim: c.expiredDepositRewards,
+                        rewardOwner: c.rewardOwner
+                            ? c.rewardOwner
+                            : {
+                                  addresses: owners[idx].addresses,
+                                  threshold: owners[idx].threshold,
+                                  locktime: new BN(owners[idx].locktime),
+                              },
+                    })
+                }
+
+                try {
+                    const treasuryRewards = await ava.PChain().getClaimables(owners)
+                    treasuryRewards.claimables.forEach((c, idx) => {
+                        if (!c.expiredDepositRewards.isZero()) pushReward(c, idx, false)
+                        if (!c.validatorRewards.isZero()) pushReward(c, idx, true)
+                    })
+                    if (!validatorFound) {
+                        const v = getters.getValidatorByRewardOwner(addresses) as ValidatorRaw
+                        if (v)
+                            pushReward(
+                                {
+                                    rewardOwner: {
+                                        addresses: v.rewardOwner.addresses,
+                                        threshold: parseInt(v.rewardOwner.threshold),
+                                        locktime: new BN(v.rewardOwner.locktime),
+                                    },
+                                    validatorRewards: ZeroBN,
+                                    expiredDepositRewards: ZeroBN,
+                                },
+                                -1,
+                                true
+                            )
+                    }
+                } catch (e: unknown) {
+                    console.log(e)
+                }
             }
+            state.rewards = newRewards
+        },
+        async updateAddressStates({ commit, rootState }) {
+            const address = rootState.activeWallet?.getStaticAddress('P')
+            const states = address ? await ava.PChain().getAddressStates(address) : ZeroBN
+            commit('setAddressStates', states)
+        },
+        async updateSunrisePhase({ commit }) {
+            let sp = 0
+            try {
+                let res = await ava.PChain().getUpgradePhases()
+                sp = res.SunrisePhase
+            } catch (e: any) {
+                if ((e.message as string).indexOf('platform.GetUpgradePhases') > 0)
+                    console.log(e.message)
+                throw e
+            }
+            commit('setSunrisePhase', sp)
+        },
+        addAllowedAddresses: async (
+            { rootState },
+            {
+                allowedAddresses,
+                depositOfferID,
+                timestamp,
+            }: {
+                allowedAddresses: { address: string }[]
+                depositOfferID: string
+                timestamp: number
+            }
+        ) => {
+            const wallet = rootState.activeWallet
+            const addressString = wallet?.getStaticAddress('P')
+            let shortIDAddresses = allowedAddresses.map((elem) => {
+                return bintools.cb58Encode(ava.PChain().parseAddress(elem.address))
+            })
+            if (!wallet || !addressString) return
+            let signer: SECP256k1KeyPair | undefined = wallet?.getStaticKeyPair()
+            let signatures = allowedAddresses.map((elem) => {
+                const msgHashed: Buffer = Buffer.from(
+                    createHash('sha256')
+                        .update(
+                            Buffer.concat([
+                                bintools.cb58Decode(depositOfferID),
+                                ava.PChain().parseAddress(elem.address),
+                            ])
+                        )
+                        .digest()
+                )
+                return signer?.sign(msgHashed).toString('hex')
+            })
+            const result = await SignaVaultDepositOfferApi().addSignature({
+                addresses: shortIDAddresses,
+                depositOfferID: depositOfferID,
+                signatures: signatures as string[],
+                timestamp,
+            })
+        },
+        async updateRestrictedOffers({ state, rootState }) {
+            const wallet = rootState.activeWallet
+            const addressString = wallet?.getStaticAddress('P')
+            if (!wallet || !addressString) return
+            const address = ava.PChain().parseAddress(addressString)
+            let signer: SECP256k1KeyPair | undefined = wallet?.getStaticKeyPair()
+            const timestamp = Math.floor(Date.now() / 1000).toString()
+            const hashedMessage = Buffer.from(
+                createHash('sha256')
+                    .update(Buffer.concat([address, Buffer.from(timestamp)]))
+                    .digest()
+            )
+            const signatureTimestamp = signer?.sign(hashedMessage).toString('hex')
+            const result = await SignaVaultDepositOfferApi().getSignatures(
+                bintools.cb58Encode(address),
+                signatureTimestamp as string,
+                timestamp,
+                'false'
+            )
+            state.restrictedOffers = result.data
+        },
+        getRestrictedOffers: async ({ state, rootState }) => {
+            const wallet = rootState.activeWallet
+            const signer =
+                wallet instanceof MultisigWallet
+                    ? wallet?.wallets[0].getStaticKeyPair()
+                    : wallet?.getStaticKeyPair()
+            const addressString = wallet?.getStaticAddress('P')
+            if (!signer || !addressString) return
+            const timestamp = Math.floor(Date.now() / 1000).toString()
+            const a = ava.PChain().parseAddress(addressString)
+            const t = Buffer.from(timestamp)
+            const signature: Buffer = Buffer.concat([a, t])
+            const hashedMessage = Buffer.from(createHash('sha256').update(signature).digest())
+            const signatureAliasTimestamp = signer.sign(hashedMessage).toString('hex')
+            const result = await SignaVaultDepositOfferApi().getSignatures(
+                bintools.cb58Encode(a),
+                signatureAliasTimestamp,
+                timestamp,
+                wallet?.type === 'multisig' ? 'true' : 'false'
+            )
+            state.restrictedOffers = result.data
         },
     },
     getters: {
-        validatorListEarn(state, getters): ValidatorListItem[] {
-            // Filter validators we do not need
-            let now = Date.now()
-
-            let validators = state.validators
-            validators = validators.filter((v) => {
-                let endTime = parseInt(v.endTime) * 1000
-                let dif = endTime - now
-
-                // If End time is less than 2 weeks + 1 hour, remove from list they are no use
-                let threshold = DAY_MS * 14 + 10 * MINUTE_MS
-                if (dif <= threshold) {
-                    return false
-                }
-
-                return true
-            })
-
-            let delegatorMap: ValidatorDelegatorDict = getters.nodeDelegatorMap
-            let delegatorPendingMap: ValidatorDelegatorPendingDict = getters.nodeDelegatorPendingMap
-
-            let res: ValidatorListItem[] = []
-
-            for (var i = 0; i < validators.length; i++) {
-                let v = validators[i]
-
-                let nodeID = v.nodeID
-
-                let delegators: DelegatorRaw[] = delegatorMap[nodeID] || []
-                let delegatorsPending: DelegatorPendingRaw[] = delegatorPendingMap[nodeID] || []
-
-                let delegatedAmt = new BN(0)
-                let delegatedPendingAmt = new BN(0)
-
-                if (delegators) {
-                    delegatedAmt = delegators.reduce((acc: BN, val: DelegatorRaw) => {
-                        return acc.add(new BN(val.stakeAmount))
-                    }, new BN(0))
-                }
-
-                if (delegatorsPending) {
-                    delegatedPendingAmt = delegatorsPending.reduce(
-                        (acc: BN, val: DelegatorPendingRaw) => {
-                            return acc.add(new BN(val.stakeAmount))
-                        },
-                        new BN(0)
-                    )
-                }
-
-                let startTime = new Date(parseInt(v.startTime) * 1000)
-                let endTime = new Date(parseInt(v.endTime) * 1000)
-
-                let delegatedStake = delegatedAmt.add(delegatedPendingAmt)
-                let validatorStake = new BN(v.stakeAmount)
-                // Calculate remaining stake
-                let absMaxStake = ONEAVAX.mul(new BN(3000000))
-                let relativeMaxStake = validatorStake.mul(new BN(5))
-                let stakeLimit = BN.min(absMaxStake, relativeMaxStake)
-
-                let remainingStake = stakeLimit.sub(validatorStake).sub(delegatedStake)
-
-                let listItem: ValidatorListItem = {
-                    nodeID: v.nodeID,
-                    validatorStake: validatorStake,
-                    delegatedStake: delegatedStake,
-                    remainingStake: remainingStake,
-                    numDelegators: delegators.length + delegatorsPending.length,
-                    startTime: startTime,
-                    endTime,
-                    uptime: parseFloat(v.uptime),
-                    fee: parseFloat(v.delegationFee),
-                }
-                res.push(listItem)
-            }
-
-            res = res.filter((v) => {
-                // Remove if remaining space is less than minimum
-                let min = state.minStakeDelegation
-                if (v.remainingStake.lt(min)) return false
-                return true
-            })
-
-            return res
-        },
-
-        // Maps delegators to a node id
-
-        nodeDelegatorMap(state): ValidatorDelegatorDict {
-            let res: ValidatorDelegatorDict = {}
-            let validators = state.validators
-            for (var i = 0; i < validators.length; i++) {
-                let validator = validators[i]
-                let nodeID = validator.nodeID
-                res[nodeID] = validator.delegators || []
-            }
-            return res
-        },
-
-        nodeDelegatorPendingMap(state): ValidatorDelegatorPendingDict {
-            let res: ValidatorDelegatorPendingDict = {}
-            let delegators = state.delegatorsPending
-            for (var i = 0; i < delegators.length; i++) {
-                let delegator = delegators[i]
-                let nodeID = delegator.nodeID
-                let target = res[nodeID]
-
-                if (target) {
-                    res[nodeID].push(delegator)
-                } else {
-                    res[nodeID] = [delegator]
-                }
-            }
-            return res
-        },
-
-        // Given a validator list item, calculate the max stake of this item
-        validatorMaxStake: (state, getters) => (validator: ValidatorListItem) => {
-            let stakeAmt = validator.validatorStake
-
-            // 5 times the validator's stake
-            let relativeMaxStake = stakeAmt.mul(new BN(5))
-
-            // absolute max stake
-            let mult = new BN(10).pow(new BN(6 + 9))
-            let absMaxStake = new BN(3).mul(mult)
-
-            if (relativeMaxStake.lt(absMaxStake)) {
-                return relativeMaxStake
-            } else {
-                return absMaxStake
-            }
-        },
-
         // Return if a given nodeID is either current or pending validator
         isValidator: (state) => (nodeID: string) => {
             return (
@@ -279,11 +281,47 @@ const platform_module: Module<PlatformState, RootState> = {
                 state.validatorsPending.findIndex((v) => v.nodeID === nodeID) >= 0
             )
         },
+        getValidatorByRewardOwner: (state) => (addresses: string[]): ValidatorRaw | undefined => {
+            return state.validators.find(
+                (v) => v.rewardOwner.addresses.findIndex((a) => addresses.includes(a)) >= 0
+            )
+        },
 
-        depositOffers: (state) => (active: boolean) => {
+        depositOffers: (state, _, rootState) => (active: boolean) => {
             const lockedFlag = new BN(1)
             const expected = active ? ZeroBN : lockedFlag
-            return state.depositOffers.filter((v) => v.flags.and(lockedFlag).eq(expected))
+
+            return state.depositOffers
+                .filter((v) => v.flags.and(lockedFlag).eq(expected))
+                .filter((elem) => {
+                    const depositOwnerAddress = ava
+                        .PChain()
+                        .addressFromBuffer(bintools.cb58Decode(elem.ownerAddress as string))
+                    if (depositOwnerAddress === ava.PChain().addressFromBuffer(Buffer.alloc(20)))
+                        return true
+                    else if (state.restrictedOffers?.find((el) => elem.id === el.depositOfferID))
+                        return true
+                    else return false
+                })
+        },
+        isDepositOfferRestricted: (state, _, rootState) => (depositOfferID: string) => {
+            let restrictedDepositOffer: ModelDepositOfferSig | undefined
+            if (
+                (restrictedDepositOffer = state.restrictedOffers?.find(
+                    (el) => depositOfferID === el.depositOfferID
+                ))
+            ) {
+                return restrictedDepositOffer
+            }
+        },
+        depositOffer: (state) => (depositOfferID: string) => {
+            return state.depositOffers.find((v) => v.id === depositOfferID)
+        },
+        isOfferCreator: (state): boolean => {
+            return !state.addressStates.and(OneBN.shln(AddressState.OFFERS_CREATOR)).isZero()
+        },
+        getSunrisePhase(state): number {
+            return state.sunrisePhase
         },
     },
 }

--- a/src/store/modules/platform/types.ts
+++ b/src/store/modules/platform/types.ts
@@ -1,23 +1,70 @@
-import {
-    DelegatorPendingRaw,
-    DelegatorRaw,
-    ValidatorPendingRaw,
-    ValidatorRaw,
-    DepositOfferRaw,
-    ActiveDeposit,
-} from '@/components/misc/ValidatorList/types'
 import { BN } from '@c4tplatform/caminojs/dist'
-import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm/interfaces'
+import {
+    APIDeposit,
+    DepositOffer,
+    Owner,
+} from '@c4tplatform/caminojs/dist/apis/platformvm/interfaces'
+import { ModelDepositOfferSig } from '@c4tplatform/signavaultjs'
+
+export type RewardOwner = Owner
 
 export interface PlatformState {
     validators: ValidatorRaw[]
     validatorsPending: ValidatorPendingRaw[]
-    delegatorsPending: DelegatorPendingRaw[]
     minStake: BN
     minStakeDelegation: BN
     currentSupply: BN
     depositOffers: DepositOffer[]
-    activeDepositOffer: ActiveDeposit[]
+    rewards: PlatformRewards
+    addressStates: BN
+    sunrisePhase: number
+    restrictedOffers?: ModelDepositOfferSig[]
+}
+
+export interface ValidatorRaw {
+    connection: boolean
+    endTime: string
+    nodeID: string
+    stakeAmount: string
+    startTime: string
+    uptime: string
+    delegationFee: string
+    delegators: DelegatorRaw[] | null
+    potentialReward: string
+    rewardOwner: ValidatorRewardOwner
+    txID: string
+}
+
+export interface DelegatorRaw {
+    endTime: string
+    nodeID: string
+    potentialReward: string
+    rewardOwner: ValidatorRewardOwner
+    stakeAmount: string
+    startTime: string
+    txID: string
+}
+
+export interface DelegatorPendingRaw {
+    startTime: string
+    endTime: string
+    stakeAmount: string
+    nodeID: string
+}
+
+export interface ValidatorPendingRaw {
+    startTime: string
+    endTime: string
+    stakeAmount: string
+    nodeID: string
+    delegationFee: string
+    connected: boolean
+}
+
+export interface ValidatorRewardOwner {
+    addresses: string[]
+    locktime: string
+    threshold: string
 }
 
 export interface GetValidatorsResponse {
@@ -46,10 +93,6 @@ export interface ValidatorDict {
     [nodeId: string]: ValidatorRaw
 }
 
-export interface GetAllDepositOffersResponse {
-    depositOffers: DepositOfferRaw[]
-}
-
 export interface ValidatorListItem {
     nodeID: string
     validatorStake: BN
@@ -60,4 +103,20 @@ export interface ValidatorListItem {
     endTime: Date
     uptime: number
     fee: number
+}
+
+export interface PlatformRewardTreasury {
+    type: 'deposit' | 'validator'
+    amountToClaim: BN
+    rewardOwner: Owner
+}
+
+export interface PlatformRewardDeposit {
+    amountToClaim: BN
+    deposit: APIDeposit
+}
+
+export interface PlatformRewards {
+    treasuryRewards: PlatformRewardTreasury[]
+    depositRewards: PlatformRewardDeposit[]
 }

--- a/src/views/wallet/Earn.vue
+++ b/src/views/wallet/Earn.vue
@@ -30,12 +30,12 @@
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Vue, Component } from 'vue-property-decorator'
+import { Component, Vue } from 'vue-property-decorator'
 
-import { BN } from '@c4tplatform/caminojs/dist'
 import DepositOffers from '@/components/wallet/earn/DepositOffers.vue'
 import UserRewards from '@/components/wallet/earn/UserRewards.vue'
 import { bnToBig } from '@/helpers/helper'
+import { BN } from '@c4tplatform/caminojs/dist'
 import Big from 'big.js'
 
 @Component({
@@ -99,7 +99,8 @@ export default class Earn extends Vue {
         try {
             this.loadingRefreshDepositRewards = true
             await Promise.all([
-                this.$store.dispatch('Platform/updateActiveDepositOffer'),
+                this.$store.dispatch('Platform/updateAllDepositOffers'),
+                this.$store.dispatch('Platform/updateRewards'),
                 this.$store.dispatch('Signavault/updateTransaction'),
             ])
         } catch (error) {

--- a/src/views/wallet/Earn.vue
+++ b/src/views/wallet/Earn.vue
@@ -98,11 +98,14 @@ export default class Earn extends Vue {
     async refresh() {
         try {
             this.loadingRefreshDepositRewards = true
-            await Promise.all([
-                this.$store.dispatch('Platform/updateAllDepositOffers'),
-                this.$store.dispatch('Platform/updateRewards'),
-                this.$store.dispatch('Signavault/updateTransaction'),
-            ])
+            this.$store.dispatch('Assets/updateUTXOs').then(() => {
+                this.$store.dispatch('Platform/updateAllDepositOffers').then(async () => {
+                    await Promise.all([
+                        this.$store.dispatch('Platform/updateRewards'),
+                        this.$store.dispatch('Signavault/updateTransaction'),
+                    ])
+                })
+            })
         } catch (error) {
             console.error('Error refreshing deposit rewards:', error)
         } finally {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -81,6 +81,7 @@ module.exports = {
                 './mountsaveKyesButton': './src/views/wallet/mountSaveKeysButton.ts',
                 './mountMultisigWalletSetting': './src/views/mountMultisigWalletSetting.ts',
                 './mountVersionComponent': './src/components/misc/mountVersion.ts',
+                './mountCreateOfferForm': './src/components/wallet/earn/mountCreateOfferForm.ts',
             },
         }),
         new HtmlWebPackPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,6 +11,11 @@
     event-pubsub "4.3.0"
     js-message "1.0.7"
 
+"@adraffy/ens-normalize@1.8.9":
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.8.9.tgz#67b3acadebbb551669c9a1da15fac951db795b85"
+  integrity sha512-93OmGCV0vO8+JQ3FHG+gZk/MPHzzMPDRiCiFcCQNTCnHaaxsacO3ScTPGlu2wX2dOtgfalbchPcw1cOYYjHCYQ==
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.1.tgz#99e8e11851128b8702cd57c33684f1d0f260b630"
@@ -1062,25 +1067,25 @@
     assert "2.0.0"
     axios "^0.26.1"
     bech32 "^2.0.0"
-    bip39 "^3.0.4"
+    bip39 "3.1.0"
     bn.js "5.1.1"
     buffer "^5.5.0"
     create-hash "1.2.0"
     crypto-browserify "3.12.0"
     elliptic "6.5.4"
-    ethers "^5.7.0"
-    hdkey "2.0.1"
+    ethers "6.0.8"
+    hdkey "2.1.0"
     isomorphic-ws "5.0.0"
     randombytes "^2.1.0"
     store2 "2.14.2"
     stream-browserify "3.0.0"
-    ws "8.8.1"
+    ws "8.12.1"
     xss "1.0.14"
 
-"@c4tplatform/signavaultjs@^1.0.11":
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/@c4tplatform/signavaultjs/-/signavaultjs-1.0.11.tgz#6471a657c3ef6ed23b7c2f29953a72caf1050f90"
-  integrity sha512-t0vb7mmKgqTyfzUvtGgZ78yPuTJOfgLpXnK9JZ4hGH1w7k+2eCtaWXwxf+VFvfDpArCK06xgZzya0HZrM6mn/w==
+"@c4tplatform/signavaultjs@^1.1":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@c4tplatform/signavaultjs/-/signavaultjs-1.1.0.tgz#cae4bf9bce1d270cb7f538775f7f7dde29ba8c1a"
+  integrity sha512-Aykw4Dad3f/6eRbhExZoitLrLhRMmeXauSbXJCItnqlf1h+4T4yDhDi3rQ8P99D8KCrY+OFBD379+x0UhtuVNg==
   dependencies:
     axios "^1.3.4"
     create-hash "^1.2.0"
@@ -2295,6 +2300,11 @@
   dependencies:
     "@noble/hashes" "1.3.0"
 
+"@noble/hashes@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
+  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
 "@noble/hashes@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
@@ -2304,6 +2314,11 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
   integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+
+"@noble/secp256k1@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@node-ipc/js-queue@2.0.3":
   version "2.0.3"
@@ -4037,6 +4052,11 @@ aes-js@3.0.0:
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
   integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
 
+aes-js@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-4.0.0-beta.3.tgz#da2253f0ff03a0b3a9e445c8cbdf78e7fda7d48c"
+  integrity sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA==
+
 agent-base@6, agent-base@^6.0.0, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -4866,7 +4886,7 @@ bip32@^2.0.6:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
-bip39@^3.0.4:
+bip39@3.1.0, bip39@^3.0.4:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.1.0.tgz#c55a418deaf48826a6ceb34ac55b3ee1577e18a3"
   integrity sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==
@@ -7890,7 +7910,19 @@ ethereumjs-util@^7.0.7, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.1, ethereum
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@^5.7.0, ethers@^5.7.2:
+ethers@6.0.8:
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.0.8.tgz#a02e31f2771b66ecab6c731c1141b30d9de09174"
+  integrity sha512-j5smdMwn4t4vEARcfUv54mTJ2NMCorYLL51wPjFInEnrRr2SF5Sl9a7Z4DXS8UO1fBJVGHnjDDrF1b7msY3f7Q==
+  dependencies:
+    "@adraffy/ens-normalize" "1.8.9"
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.7.1"
+    aes-js "4.0.0-beta.3"
+    tslib "2.4.0"
+    ws "8.5.0"
+
+ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -9276,6 +9308,16 @@ hdkey@2.0.1:
   integrity sha512-c+tl9PHG9/XkGgG0tD7CJpRVaE0jfZizDNmnErUAKQ4EjQSOcOUcV3EN9ZEZS8pZ4usaeiiK0H7stzuzna8feA==
   dependencies:
     bs58check "^2.1.2"
+    safe-buffer "^5.1.1"
+    secp256k1 "^4.0.0"
+
+hdkey@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-2.1.0.tgz#755b30b73f54e93c31919c1b2f19205a8e57cb92"
+  integrity sha512-i9Wzi0Dy49bNS4tXXeGeu0vIcn86xXdPQUpEYg+SO1YiO8HtomjmmRMaRyqL0r59QfcD4PfVbSF3qmsWFwAemA==
+  dependencies:
+    bs58check "^2.1.2"
+    ripemd160 "^2.0.2"
     safe-buffer "^5.1.1"
     secp256k1 "^4.0.0"
 
@@ -14755,7 +14797,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-ripemd160@^2.0.0, ripemd160@^2.0.1:
+ripemd160@^2.0.0, ripemd160@^2.0.1, ripemd160@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
   integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==
@@ -16349,6 +16391,11 @@ tsconfig@^7.0.0:
     "@types/strip-json-comments" "0.0.30"
     strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
+
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
@@ -18134,10 +18181,15 @@ ws@7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
-ws@8.8.1:
-  version "8.8.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
-  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
+ws@8.12.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
+  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
+
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 ws@^3.0.0:
   version "3.3.3"


### PR DESCRIPTION
### Feature Enhancement: Creating depositOffers with Advanced Permissions

This PR introduces a pivotal feature allowing the creation of depositOffers with enhanced control mechanisms. The following functionalities have been implemented:

- Permission-based Display of Foundation Section:
The Foundation section in the application suite and Landing Page will now be visible only if the associated address possesses the "may-create-depositOffers" flag. This ensures a more tailored experience for users.

- New Top-level Navigation: "Foundation":
 implement a new top-level navigation named "Foundation" within the Application Suite. This will provide a dedicated space for managing depositOffers efficiently.

- Intuitive DepositOffer Creation Workflow:
Users can now navigate to the "Create new depositOffer" section, streamlining the process of initiating a new depositOffer.

- Mandatory Fields and Confirmation:
Users are required to complete all necessary fields before confirming the creation of a depositOffer, ensuring comprehensive and accurate information.

- Earn Section: Display of Open depositOffers:
Within the Earn section under "Earn now," all currently open depositOffers are now displayed for easy access.

- Address-specific Visibility for depositOffers:
depositOffers with a set of allowed addresses are only displayed to these specific addresses, enhancing privacy and security.

- Deposit Funds Modal:
Users can now click on a deposit offer to initiate a deposit. This action opens a modal displaying the details of the depositOffer.

- MSig Workflow
