### PR TITLE
improvement for create offer form

### DIFF
--- a/src/components/CamInput.vue
+++ b/src/components/CamInput.vue
@@ -43,8 +43,14 @@ export default class CamInput extends Vue {
     }
 }
 </script>
-
 <style scoped lang="scss">
+.v-application .error {
+    background-color: transparent !important;
+    border: 1px solid var(--camino-slate-slate-600);
+    &:disabled {
+        border: 1px solid var(--camino-slate-slate-600) !important;
+    }
+}
 .cam-input {
     display: flex;
     flex-direction: column;

--- a/src/components/misc/AvaxInput.vue
+++ b/src/components/misc/AvaxInput.vue
@@ -72,7 +72,6 @@ export default class AvaxInput extends Vue {
     })
     max?: BN | null
     @Prop() initial?: BN
-
     @Prop() balance?: Big | null
     @Prop() alias?: string
     @Prop() readonly?: boolean
@@ -86,7 +85,10 @@ export default class AvaxInput extends Vue {
         //@ts-ignore
         this.$refs.amt_in.maxout()
     }
-
+    reset() {
+        //@ts-ignore
+        this.$refs.amt_in.clear()
+    }
     amount_in(val: BN) {
         this.$emit('change', val)
     }
@@ -215,6 +217,10 @@ export default class AvaxInput extends Vue {
 .ticker {
     border-radius: var(--border-radius-sm);
     padding: 10px 12px;
+    border: 1px solid var(--camino-slate-slate-600);
+    &:disabled {
+        border: 1px solid var(--camino-slate-slate-600) !important;
+    }
 }
 
 .max_but {

--- a/src/components/misc/CamTooltip.vue
+++ b/src/components/misc/CamTooltip.vue
@@ -44,10 +44,10 @@ export default {
     bottom: 150%;
     left: 50%;
     transform: translateX(-50%);
-    white-space: nowrap;
     display: none;
     font-size: 14px;
     line-height: 22px;
+    z-index: 1;
 }
 
 .tooltip-content:after {
@@ -69,7 +69,8 @@ export default {
     top: 50%;
     left: 240%;
     transform: translateY(-50%);
-    white-space: nowrap;
+    width: max-content;
+    max-width: 300px;
     bottom: auto;
 }
 
@@ -88,6 +89,8 @@ export default {
 .tooltip[placement='bottom'] .tooltip-content {
     top: 180%;
     left: 50%;
+    width: max-content;
+    max-width: 300px;
     transform: translateX(-50%);
     bottom: auto;
 }
@@ -106,6 +109,8 @@ export default {
     right: 250%;
     left: auto;
     top: 50%;
+    width: max-content;
+    max-width: 300px;
     transform: translateY(-50%);
     bottom: auto;
 }

--- a/src/components/wallet/earn/CreateOfferForm.vue
+++ b/src/components/wallet/earn/CreateOfferForm.vue
@@ -2,7 +2,12 @@
     <div class="create-offer__container">
         <div v-if="!pendingCreateOfferMultisigTX" class="create-offer__container__form">
             <div class="create-offer__container__form__element full-width">
-                <label>{{ $t('earn.rewards.create.memo').toString() }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.memo').toString() }}</label>
+                    <cam-tooltip :content="$t('earn.rewards.descriptions.title')" placement="right">
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <cam-input
                     class="input"
                     v-model="offer.memo"
@@ -12,7 +17,15 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>{{ $t('earn.rewards.create.offer_start') }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.offer_start') }}</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.offer_start')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <DateForm
                     class="input"
                     :minDurationMs="minDuration"
@@ -22,7 +35,15 @@
                 ></DateForm>
             </div>
             <div class="create-offer__container__form__element">
-                <label>{{ $t('earn.rewards.create.offer_end') }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.offer_end') }}</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.offer_end')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <DateForm
                     class="input"
                     :minDurationMs="minDuration"
@@ -32,7 +53,15 @@
                 ></DateForm>
             </div>
             <div class="create-offer__container__form__element">
-                <label>{{ $t('earn.rewards.create.min_amount') }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.min_amount') }}</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.min_amount')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <AvaxInput
                     class="input"
                     v-model="offer.minAmount"
@@ -48,34 +77,125 @@
                     "
                 />
             </div>
+            <v-tabs
+                class="create-offer__container__form__element tabs"
+                height="38"
+                :grow="true"
+                :show-arrows="false"
+                :centered="true"
+                v-model="selectedTab"
+                :mobile-breakpoint="900"
+            >
+                <v-tab key="mnemonic">Max Amount</v-tab>
+                <v-tab key="keystore">Interest</v-tab>
+                <v-tab-item>
+                    <div class="create-offer__container__form__element">
+                        <div>
+                            <label>
+                                {{ $t('earn.rewards.create.total_max_amount') }}
+                            </label>
+                            <cam-tooltip
+                                :content="$t('earn.rewards.descriptions.max_amount')"
+                                placement="right"
+                            >
+                                <fa icon="question-circle"></fa>
+                            </cam-tooltip>
+                        </div>
+                        <AvaxInput
+                            ref="totalMaxAmount"
+                            class="input"
+                            v-model="offer.totalMaxAmount"
+                            :initial="offer.totalMaxAmount"
+                            :max="maxDepositAmount"
+                            :camInput="true"
+                        ></AvaxInput>
+                    </div>
+                </v-tab-item>
+                <v-tab-item>
+                    <div class="create-offer__container__form__element">
+                        <div>
+                            <label>
+                                {{ $t('earn.rewards.create.interrest_rate') }}
+                            </label>
+                            <cam-tooltip
+                                :content="$t('earn.rewards.descriptions.interest_rate')"
+                                placement="right"
+                            >
+                                <fa icon="question-circle"></fa>
+                            </cam-tooltip>
+                        </div>
+                        <CamInput
+                            class="input"
+                            v-model="interestRateNominator"
+                            v-on:input="setInterestRate"
+                            :placeholder="`interestRateNominator`"
+                            :error="interestRateAndTotalMaxRewardAmountError"
+                            :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
+                        />
+                    </div>
+                    <div class="create-offer__container__form__element">
+                        <div>
+                            <label>
+                                {{ $t('earn.rewards.create.total_max_reward_amount') }}
+                            </label>
+                            <cam-tooltip
+                                :content="$t('earn.rewards.descriptions.total_max_reward_amount')"
+                                placement="right"
+                            >
+                                <fa icon="question-circle"></fa>
+                            </cam-tooltip>
+                        </div>
+                        <CamInput
+                            class="input"
+                            v-model="totalMaxRewardAmount"
+                            v-on:input="setTotalMaxRewardAmount"
+                            :placeholder="`totalMaxRewardAmount`"
+                            :readonly="sunrisePhase === 0"
+                            :error="interestRateAndTotalMaxRewardAmountError"
+                            :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
+                        ></CamInput>
+                    </div>
+                </v-tab-item>
+            </v-tabs>
+
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.total_max_amount') }}
-                </label>
-                <AvaxInput
-                    class="input"
-                    v-model="offer.totalMaxAmount"
-                    :initial="offer.totalMaxAmount"
-                    :max="maxDepositAmount"
-                    :camInput="true"
-                ></AvaxInput>
-            </div>
-            <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.min_duration') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.min_duration') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.minimum_duration')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput class="input" :placeholder="`minDuration`" v-model="offer.minDuration" />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.max_duration') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.max_duration') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.maximum_duration')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput class="input" :placeholder="`maxDuration`" v-model="offer.maxDuration" />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.unlock_duration') }}
-                </label>
+                <div>
+                    <label>Vesting Period</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.vesting_period')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="offer.unlockPeriodDuration"
@@ -83,46 +203,31 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.no_rewards_duration') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.no_rewards_duration') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.period_without_rewards')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="offer.noRewardsPeriodDuration"
                     :placeholder="`noRewardsPeriodDuration`"
                 />
             </div>
-            <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.interrest_rate') }}
-                </label>
-                <CamInput
-                    class="input"
-                    v-model="interestRateNominator"
-                    v-on:input="setInterestRate"
-                    :placeholder="`interestRateNominator`"
-                    :error="interestRateAndTotalMaxRewardAmountError"
-                    :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
-                />
-            </div>
-            <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.total_max_reward_amount') }}
-                </label>
-                <CamInput
-                    class="input"
-                    v-model="totalMaxRewardAmount"
-                    v-on:input="setTotalMaxRewardAmount"
-                    :placeholder="`totalMaxRewardAmount`"
-                    :readonly="sunrisePhase === 0"
-                    :error="interestRateAndTotalMaxRewardAmountError"
-                    :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
-                ></CamInput>
-            </div>
-            <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.flags') }}
-                </label>
+
+            <!-- <div class="create-offer__container__form__element">
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.flags') }}
+                    </label>
+
+                </div>
                 <input
                     class="input"
                     type="number"
@@ -131,51 +236,53 @@
                     min="0"
                     inputmode="numeric"
                 />
-            </div>
-            <div v-if="!isMultisigWallet" class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.owner_address') }}
-                </label>
-                <CamInput
-                    class="input"
-                    :placeholder="`ownerAddress`"
-                    v-model.number="offer.ownerAddress"
-                    :disabled="sunrisePhase === 0"
-                    :error="ownerAddressCheck"
-                    :errorMessage="ownerAddressCheck"
-                />
-            </div>
+            </div> -->
             <div v-if="!isMultisigWallet" class="create-offer__container__form__element full-width">
-                <label>Addresses allowed to deposit</label>
-                <div class="addresses_container input">
-                    <div v-for="(address, index) in addresses" :key="index">
-                        <div class="address_container">
-                            <button @click="removeAddress(index)" class="circle delete-button">
-                                <CamTooltip
-                                    :content="$t('edit_multisig.label.remove_owner')"
-                                    placement="left"
-                                >
-                                    <fa icon="minus"></fa>
-                                </CamTooltip>
-                            </button>
-                            <CamInput
-                                class="input"
-                                v-model="address.address"
-                                :disabled="
-                                    !offer.ownerAddress || ownerAddressCheck === 'Invalid address'
-                                "
-                            />
+                <div class="restricted__container">
+                    <v-checkbox
+                        label="Restricted"
+                        v-model="isRestricted"
+                        class="checkbox"
+                    ></v-checkbox>
+                    <cam-tooltip
+                        class="restricted__container__description"
+                        :content="$t('earn.rewards.descriptions.restricted')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
+                <template v-if="isRestricted">
+                    <label style="margin-top: 16px">Addresses allowed to deposit</label>
+                    <div class="addresses_container input">
+                        <div v-for="(address, index) in addresses" :key="index">
+                            <div class="address_container">
+                                <button @click="removeAddress(index)" class="circle delete-button">
+                                    <CamTooltip
+                                        :content="$t('edit_multisig.label.remove_owner')"
+                                        placement="left"
+                                    >
+                                        <fa icon="minus"></fa>
+                                    </CamTooltip>
+                                </button>
+                                <CamInput class="input" v-model="address.address" />
+                            </div>
                         </div>
                     </div>
-                </div>
-                <button @click.prevent="addAddress" class="circle plus-button">
-                    <fa icon="plus"></fa>
-                </button>
+                    <button @click.prevent="addAddress" class="circle plus-button">
+                        <fa icon="plus"></fa>
+                    </button>
+                </template>
             </div>
         </div>
         <div v-else class="create-offer__container__form">
             <div class="create-offer__container__form__element full-width">
-                <label>{{ $t('earn.rewards.create.memo').toString() }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.memo').toString() }}</label>
+                    <cam-tooltip :content="$t('earn.rewards.descriptions.title')" placement="right">
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <cam-input
                     class="input"
                     v-model="pendingOffer.memo"
@@ -184,7 +291,15 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>{{ $t('earn.rewards.create.offer_start') }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.offer_start') }}</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.offer_start')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <DateForm
                     class="input"
                     :minDurationMs="minDuration"
@@ -195,7 +310,15 @@
                 ></DateForm>
             </div>
             <div class="create-offer__container__form__element">
-                <label>{{ $t('earn.rewards.create.offer_end') }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.offer_end') }}</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.offer_end')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <DateForm
                     class="input"
                     :minDurationMs="minDuration"
@@ -206,7 +329,15 @@
                 ></DateForm>
             </div>
             <div class="create-offer__container__form__element">
-                <label>{{ $t('earn.rewards.create.min_amount') }}</label>
+                <div>
+                    <label>{{ $t('earn.rewards.create.min_amount') }}</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.min_amount')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="pendingOffer.minAmount"
@@ -214,9 +345,17 @@
                 ></CamInput>
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.total_max_amount') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.total_max_amount') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.max_amount')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="pendingOffer.totalMaxAmount"
@@ -224,9 +363,17 @@
                 ></CamInput>
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.min_duration') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.min_duration') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.minimum_duration')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     :placeholder="`minDuration`"
@@ -235,9 +382,17 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.max_duration') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.max_duration') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.maximum_duration')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     :placeholder="`maxDuration`"
@@ -246,9 +401,15 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.unlock_duration') }}
-                </label>
+                <div>
+                    <label>Vesting Period</label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.vesting_period')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="pendingOffer.unlockPeriodDuration"
@@ -257,9 +418,17 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.no_rewards_duration') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.no_rewards_duration') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.period_without_rewards')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="pendingOffer.noRewardsPeriodDuration"
@@ -268,9 +437,17 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.interrest_rate') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.interrest_rate') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.interest_rate')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="pendingOffer.interestRateNominator"
@@ -279,9 +456,17 @@
                 />
             </div>
             <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.total_max_reward_amount') }}
-                </label>
+                <div>
+                    <label>
+                        {{ $t('earn.rewards.create.total_max_reward_amount') }}
+                    </label>
+                    <cam-tooltip
+                        :content="$t('earn.rewards.descriptions.total_max_reward_amount')"
+                        placement="right"
+                    >
+                        <fa icon="question-circle"></fa>
+                    </cam-tooltip>
+                </div>
                 <CamInput
                     class="input"
                     v-model="pendingOffer.totalMaxRewardAmount"
@@ -289,52 +474,12 @@
                     :disabled="true"
                 ></CamInput>
             </div>
-            <div class="create-offer__container__form__element">
+            <!-- <div class="create-offer__container__form__element">
                 <label>
                     {{ $t('earn.rewards.create.flags') }}
                 </label>
                 <input class="input" :value="pendingOffer.flags" :disabled="true" />
-            </div>
-            <div v-if="!isMultisigWallet" class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.owner_address') }}
-                </label>
-                <CamInput
-                    class="input"
-                    :placeholder="`ownerAddress`"
-                    v-model.number="offer.ownerAddress"
-                    :disabled="sunrisePhase === 0"
-                    :error="ownerAddressCheck"
-                    :errorMessage="ownerAddressCheck"
-                />
-            </div>
-            <div v-if="!isMultisigWallet" class="create-offer__container__form__element full-width">
-                <label>Addresses allowed to deposit</label>
-                <div class="addresses_container input">
-                    <div v-for="(address, index) in addresses" :key="index">
-                        <div class="address_container">
-                            <button @click="removeAddress(index)" class="circle delete-button">
-                                <CamTooltip
-                                    :content="$t('edit_multisig.label.remove_owner')"
-                                    placement="left"
-                                >
-                                    <fa icon="minus"></fa>
-                                </CamTooltip>
-                            </button>
-                            <CamInput
-                                class="input"
-                                v-model="address.address"
-                                :disabled="
-                                    !offer.ownerAddress || ownerAddressCheck === 'Invalid address'
-                                "
-                            />
-                        </div>
-                    </div>
-                </div>
-                <button @click.prevent="addAddress" class="circle plus-button">
-                    <fa icon="plus"></fa>
-                </button>
-            </div>
+            </div> -->
         </div>
         <div class="create-offer__container__actions">
             <div class="create-offer__container__actions__aletrs">
@@ -428,8 +573,9 @@ import {
 import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 
-const MAX_TITLE_BYTE_SIZE = 64
+const MAX_TITLE_BYTE_SIZE = 256
 
+import CamTooltip from '@/components/misc/CamTooltip.vue'
 import ModalAbortSigning from '@/components/wallet/earn/ModalAbortSigning.vue'
 import { WalletHelper } from '@/helpers/wallet_helper'
 import { MultisigWallet } from '@/js/wallets/MultisigWallet'
@@ -439,13 +585,15 @@ import { SignatureError } from '@c4tplatform/caminojs/dist/common'
 import DateForm from './DateForm.vue'
 
 @Component({
-    components: { CamInput, CamBtn, Alert, DateForm, AvaxInput, ModalAbortSigning },
+    components: { CamInput, CamBtn, Alert, DateForm, AvaxInput, ModalAbortSigning, CamTooltip },
 })
 export default class CreateOfferForm extends Vue {
     @Prop() maxDepositAmount!: BN
     interestRateNominator = ZeroBN
     totalMaxRewardAmount = ZeroBN
+    isRestricted = false
     pendingOffer: any = { memo: '' }
+    selectedTab: number = 0
     // @ts-ignore
     helpers = this.globalHelper()
     addresses: { address: string }[] = [{ address: '' }]
@@ -551,13 +699,7 @@ export default class CreateOfferForm extends Vue {
         // Error if only one of them is non-zero (XOR condition)
         return interestRateNotZero !== totalMaxRewardAmountNotZero
     }
-    get ownerAddressCheck() {
-        if (!this.offer.ownerAddress) return ''
-        return !isValidPChainAddress(this.offer.ownerAddress as string) ||
-            this.offer.ownerAddress != this.wallet?.getStaticAddress('P')
-            ? 'Invalid address'
-            : ''
-    }
+
     get validAddressError(): boolean {
         const filledAddresses = this.addresses.filter((a) => a.address !== '')
 
@@ -575,7 +717,8 @@ export default class CreateOfferForm extends Vue {
 
     /* methods */
     async submitCreateOffer() {
-        if (this.offer.ownerAddress === '') this.offer.ownerAddress = undefined
+        if (!this.isRestricted) this.offer.ownerAddress = undefined
+        else this.offer.ownerAddress = this.wallet?.getStaticAddress('P')
         const wallet: WalletType = this.$store.state.activeWallet
         let offer = {
             ...this.offer,
@@ -583,6 +726,7 @@ export default class CreateOfferForm extends Vue {
             maxDuration: this.offer.maxDuration * 24 * 60 * 60,
             unlockPeriodDuration: this.offer.unlockPeriodDuration * 24 * 60 * 60,
             noRewardsPeriodDuration: this.offer.noRewardsPeriodDuration * 24 * 60 * 60,
+            interestRateNominator: new BN(this.offer.interestRateNominator * 10000),
         }
         let addresses = this.addresses.filter((a) => a.address !== '')
         try {
@@ -706,7 +850,7 @@ export default class CreateOfferForm extends Vue {
     setInterestRate(ev: any) {
         if (ev && ev.target) {
             const interestRateValue = ev.target.value
-            this.offer.interestRateNominator = new BN(interestRateValue)
+            this.offer.interestRateNominator = interestRateValue
         }
     }
     setFlags(ev: any) {
@@ -784,11 +928,20 @@ export default class CreateOfferForm extends Vue {
     /* watchers */
     @Watch('interestRateNominator')
     onInterestRateNominatorChange() {
-        this.offer.interestRateNominator = new BN(this.interestRateNominator)
+        this.offer.interestRateNominator = this.interestRateNominator
     }
     @Watch('totalMaxRewardAmount')
     onTotalMaxRewardAmountChange() {
         this.offer.totalMaxRewardAmount = new BN(this.totalMaxRewardAmount)
+    }
+    @Watch('selectedTab')
+    onSelectedTabChange() {
+        if (this.selectedTab === 0) {
+            this.interestRateNominator = ZeroBN
+            this.totalMaxRewardAmount = ZeroBN
+        } else {
+            this.$refs.totalMaxAmount?.reset()
+        }
     }
     @Watch('pendingCreateOfferMultisigTX')
     getPandingCreateOfferTxData() {
@@ -834,6 +987,7 @@ export default class CreateOfferForm extends Vue {
     /* refs */
     $refs!: {
         modal_abort_signing: ModalAbortSigning
+        totalMaxAmount: AvaxInput
     }
     /* utiils */
     clearOffer() {
@@ -854,14 +1008,47 @@ export default class CreateOfferForm extends Vue {
             ownerAddress: '',
         }
         this.setInterestRate({ target: { value: 0 } })
-        this.setFlags({ target: { value: 0 } })
         this.setTotalMaxRewardAmount({ target: { value: 0 } })
+        this.setFlags({ target: { value: 0 } })
     }
 }
 </script>
+<style lang="scss">
+.v-input--checkbox {
+    .v-input__control {
+        .v-input__slot {
+            margin-bottom: 0 !important;
+        }
+        .v-messages {
+            display: none !important;
+        }
+        .v-input--selection-controls__input {
+            margin-right: 8px !important;
+        }
+    }
+}
+.tabs {
+    width: 100%;
+    .v-item-group,
+    .v-slide-group,
+    .v-tabs-bar {
+        width: 100%;
+    }
+    .v-window-item {
+        display: flex;
+        gap: 16px;
+        margin-top: 16px;
+        &--active {
+            display: flex;
+            flex-wrap: wrap;
+        }
+    }
+}
+</style>
 <style scoped lang="scss">
 @use '../../../styles/abstracts/mixins';
 .create-offer__container {
+    width: 50%;
     display: flex;
     flex-direction: column;
     gap: 16px;
@@ -877,6 +1064,9 @@ export default class CreateOfferForm extends Vue {
             align-items: flex-start;
             gap: 4px;
             align-self: stretch;
+            label {
+                margin-right: 4px;
+            }
             .input {
                 width: 100%;
             }
@@ -889,7 +1079,8 @@ export default class CreateOfferForm extends Vue {
                 }
             }
         }
-        .full-width {
+        .full-width,
+        .tabs {
             flex: 1 1 100%;
         }
     }
@@ -911,7 +1102,7 @@ export default class CreateOfferForm extends Vue {
         display: flex;
         flex-direction: column;
         gap: 16px;
-        margin-bottom: 16px;
+        margin: 16px 0;
     }
     .address_container {
         display: flex;
@@ -919,7 +1110,15 @@ export default class CreateOfferForm extends Vue {
         align-items: center;
         gap: 16px;
     }
-
+    .restricted__container {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 4px;
+        &__description {
+            margin: 7px 0 0 4px;
+        }
+    }
     .circle {
         border: 2px solid var(--camino-slate-slate-600);
         cursor: pointer;
@@ -964,6 +1163,11 @@ export default class CreateOfferForm extends Vue {
         .delete-button.desktop {
             display: none;
         }
+    }
+}
+@include mixins.mobile-device {
+    .create-offer__container {
+        width: 100% !important;
     }
 }
 </style>

--- a/src/components/wallet/earn/CreateOfferForm.vue
+++ b/src/components/wallet/earn/CreateOfferForm.vue
@@ -86,8 +86,8 @@
                 v-model="selectedTab"
                 :mobile-breakpoint="900"
             >
-                <v-tab key="mnemonic">Max Amount</v-tab>
-                <v-tab key="keystore">Interest</v-tab>
+                <v-tab key="max_amount">Max Amount</v-tab>
+                <v-tab key="interest">Interest</v-tab>
                 <v-tab-item>
                     <div class="create-offer__container__form__element">
                         <div>
@@ -129,8 +129,6 @@
                             v-model="interestRateNominator"
                             v-on:input="setInterestRate"
                             :placeholder="`interestRateNominator`"
-                            :error="interestRateAndTotalMaxRewardAmountError"
-                            :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
                         />
                     </div>
                     <div class="create-offer__container__form__element">
@@ -151,8 +149,6 @@
                             v-on:input="setTotalMaxRewardAmount"
                             :placeholder="`totalMaxRewardAmount`"
                             :readonly="sunrisePhase === 0"
-                            :error="interestRateAndTotalMaxRewardAmountError"
-                            :errorMessage="`Interest rate must be 0 if total max reward amount is 0, and vice versa`"
                         ></CamInput>
                     </div>
                 </v-tab-item>
@@ -344,24 +340,80 @@
                     :disabled="true"
                 ></CamInput>
             </div>
-            <div class="create-offer__container__form__element">
-                <div>
-                    <label>
-                        {{ $t('earn.rewards.create.total_max_amount') }}
-                    </label>
-                    <cam-tooltip
-                        :content="$t('earn.rewards.descriptions.max_amount')"
-                        placement="right"
-                    >
-                        <fa icon="question-circle"></fa>
-                    </cam-tooltip>
-                </div>
-                <CamInput
-                    class="input"
-                    v-model="pendingOffer.totalMaxAmount"
-                    :disabled="true"
-                ></CamInput>
-            </div>
+            <v-tabs
+                class="create-offer__container__form__element tabs"
+                height="38"
+                :grow="true"
+                :show-arrows="false"
+                :centered="true"
+                v-model="selectedTab"
+                :mobile-breakpoint="900"
+                :disabled="true"
+                :aria-disabled="true"
+            >
+                <v-tab :disabled="true" key="max_amount">Max Amount</v-tab>
+                <v-tab :disabled="true" key="interest">Interest</v-tab>
+                <v-tab-item>
+                    <div class="create-offer__container__form__element">
+                        <div>
+                            <label>
+                                {{ $t('earn.rewards.create.total_max_amount') }}
+                            </label>
+                            <cam-tooltip
+                                :content="$t('earn.rewards.descriptions.max_amount')"
+                                placement="right"
+                            >
+                                <fa icon="question-circle"></fa>
+                            </cam-tooltip>
+                        </div>
+                        <CamInput
+                            class="input"
+                            v-model="pendingOffer.totalMaxAmount"
+                            :disabled="true"
+                        ></CamInput>
+                    </div>
+                </v-tab-item>
+                <v-tab-item>
+                    <div class="create-offer__container__form__element">
+                        <div>
+                            <label>
+                                {{ $t('earn.rewards.create.interrest_rate') }}
+                            </label>
+                            <cam-tooltip
+                                :content="$t('earn.rewards.descriptions.interest_rate')"
+                                placement="right"
+                            >
+                                <fa icon="question-circle"></fa>
+                            </cam-tooltip>
+                        </div>
+                        <CamInput
+                            class="input"
+                            v-model="pendingOffer.interestRateNominator"
+                            :placeholder="`interestRateNominator`"
+                            :disabled="true"
+                        />
+                    </div>
+                    <div class="create-offer__container__form__element">
+                        <div>
+                            <label>
+                                {{ $t('earn.rewards.create.total_max_reward_amount') }}
+                            </label>
+                            <cam-tooltip
+                                :content="$t('earn.rewards.descriptions.total_max_reward_amount')"
+                                placement="right"
+                            >
+                                <fa icon="question-circle"></fa>
+                            </cam-tooltip>
+                        </div>
+                        <CamInput
+                            class="input"
+                            v-model="pendingOffer.totalMaxRewardAmount"
+                            :placeholder="`totalMaxRewardAmount`"
+                            :disabled="true"
+                        ></CamInput>
+                    </div>
+                </v-tab-item>
+            </v-tabs>
             <div class="create-offer__container__form__element">
                 <div>
                     <label>
@@ -436,76 +488,61 @@
                     :disabled="true"
                 />
             </div>
-            <div class="create-offer__container__form__element">
-                <div>
-                    <label>
-                        {{ $t('earn.rewards.create.interrest_rate') }}
-                    </label>
-                    <cam-tooltip
-                        :content="$t('earn.rewards.descriptions.interest_rate')"
-                        placement="right"
-                    >
-                        <fa icon="question-circle"></fa>
-                    </cam-tooltip>
-                </div>
-                <CamInput
-                    class="input"
-                    v-model="pendingOffer.interestRateNominator"
-                    :placeholder="`interestRateNominator`"
-                    :disabled="true"
-                />
-            </div>
-            <div class="create-offer__container__form__element">
-                <div>
-                    <label>
-                        {{ $t('earn.rewards.create.total_max_reward_amount') }}
-                    </label>
-                    <cam-tooltip
-                        :content="$t('earn.rewards.descriptions.total_max_reward_amount')"
-                        placement="right"
-                    >
-                        <fa icon="question-circle"></fa>
-                    </cam-tooltip>
-                </div>
-                <CamInput
-                    class="input"
-                    v-model="pendingOffer.totalMaxRewardAmount"
-                    :placeholder="`totalMaxRewardAmount`"
-                    :disabled="true"
-                ></CamInput>
-            </div>
-            <!-- <div class="create-offer__container__form__element">
-                <label>
-                    {{ $t('earn.rewards.create.flags') }}
-                </label>
-                <input class="input" :value="pendingOffer.flags" :disabled="true" />
-            </div> -->
         </div>
         <div class="create-offer__container__actions">
             <div class="create-offer__container__actions__aletrs">
+                <template v-if="pendingCreateOfferMultisigTX">
+                    <Alert variant="info">
+                        {{
+                            $t('earn.validate.pending_multisig.threshold', {
+                                value: sigValue,
+                                threshold: pendingCreateOfferMultisigTX?.tx.threshold,
+                            })
+                        }}
+                    </Alert>
+                    <Alert v-if="SignStatus" variant="info">
+                        {{ $t('earn.validate.pending_multisig.already_signed') }}
+                    </Alert>
+                </template>
                 <Alert style="margin-top: 16px" variant="negative" v-if="validAddressError">
                     {{ $t('edit_multisig.errors.invalid_addresses') }}
                 </Alert>
                 <Alert v-if="hasExclusiveTotalMaxAmountOrReward" variant="negative">
-                    can only use either TotalMaxAmount or TotalMaxRewardAmount
+                    {{ $t('earn.rewards.errors.has_exclusive_total_max_amount_or_reward') }}
+                </Alert>
+                <Alert v-if="isMaxRewardAmountAndInterestRateIsZero" variant="negative">
+                    {{ $t('earn.rewards.errors.is_max_reward_amount_and_interest_rate_is_zero') }}
                 </Alert>
                 <Alert v-if="isMinDurationLessThanNoRewardsPeriod" variant="negative">
-                    deposit offer minimum duration ({{ offer.minDuration }}) is less than no-rewards
-                    period duration ({{ offer.noRewardsPeriodDuration }})
+                    {{
+                        $t('earn.rewards.errors.is_min_duration_less_than_no_rewards_period', {
+                            minDuration: offer.minDuration,
+                            noRewardsPeriodDuration: offer.noRewardsPeriodDuration,
+                        })
+                    }}
                 </Alert>
+
                 <Alert v-if="isMinDurationLessThanUnlockPeriod" variant="negative">
-                    deposit offer minimum duration ({{ offer.minDuration }}) is less than unlock
-                    period duration ({{ offer.unlockPeriodDuration }})
+                    {{
+                        $t('earn.rewards.errors.is_min_duration_less_than_unlock_period', {
+                            minDuration: offer.minDuration,
+                            unlockPeriodDuration: offer.unlockPeriodDuration,
+                        })
+                    }}
                 </Alert>
                 <Alert v-if="isMaxDirationLessThanMinDuration" variant="negative">
-                    deposit offer max duration ({{ offer.maxDuration }}) is less than minimum
-                    duration ({{ offer.minDuration }})
+                    {{
+                        $t('earn.rewards.errors.is_max_diration_less_than_min_duration', {
+                            minDuration: offer.minDuration,
+                            maxDuration: offer.maxDuration,
+                        })
+                    }}
                 </Alert>
                 <Alert v-if="isMinDurationEqualtoZero" variant="negative">
-                    deposit offer has zero minimum duration
+                    {{ $t('earn.rewards.errors.is_min_duration_equal_to_zero') }}
                 </Alert>
                 <Alert v-if="isStartDateGreaterThanEndDate" variant="negative">
-                    deposit offer start date is greater than end date
+                    {{ $t('earn.rewards.errors.is_start_date_greater_than_end_date') }}
                 </Alert>
                 <Alert variant="warning">
                     Creating this depositOffer will incurr a fee of
@@ -676,6 +713,13 @@ export default class CreateOfferForm extends Vue {
     get isMinDurationLessThanNoRewardsPeriod() {
         return Number(this.offer.minDuration) < Number(this.offer.noRewardsPeriodDuration)
     }
+    get isMaxRewardAmountAndInterestRateIsZero() {
+        const interestRateNominator = new BN(this.interestRateNominator)
+        const totalMaxRewardAmount = new BN(this.totalMaxRewardAmount)
+        if (interestRateNominator.isZero() && !totalMaxRewardAmount.isZero()) return true
+        else if (!interestRateNominator.isZero() && totalMaxRewardAmount.isZero()) return true
+        return false
+    }
     // deposit offer minimum duration (86400) is less than unlock period duration (864002)
     get isMinDurationLessThanUnlockPeriod() {
         return Number(this.offer.minDuration) < Number(this.offer.unlockPeriodDuration)
@@ -711,7 +755,18 @@ export default class CreateOfferForm extends Vue {
     }
     /* validation */
     get formValid(): boolean {
-        if (this.offer.start > this.offer.end) return false
+        if (
+            this.offer.start > this.offer.end ||
+            this.hasExclusiveTotalMaxAmountOrReward ||
+            this.isMaxRewardAmountAndInterestRateIsZero ||
+            this.isMinDurationLessThanNoRewardsPeriod ||
+            this.isMinDurationLessThanUnlockPeriod ||
+            this.isMaxDirationLessThanMinDuration ||
+            this.isMinDurationEqualtoZero ||
+            this.isStartDateGreaterThanEndDate ||
+            this.minAmountError
+        )
+            return false
         return true
     }
 
@@ -893,6 +948,23 @@ export default class CreateOfferForm extends Vue {
     get txOwners() {
         return this.pendingCreateOfferMultisigTX?.tx?.owners ?? []
     }
+    get sigValue() {
+        return this.pendingCreateOfferMultisigTX?.tx.owners?.filter((owner) => !!owner.signature)
+            ?.length
+    }
+    get SignStatus(): boolean {
+        let isSigned = false
+        this.txOwners.forEach((owner) => {
+            if (
+                (this.wallet as MultisigWallet).wallets.find(
+                    (w) => w?.getAllAddressesP()?.[0] === owner.address
+                )
+            ) {
+                if (owner.signature) isSigned = true
+            }
+        })
+        return isSigned
+    }
     get wallet(): WalletType {
         return this.$store.state.activeWallet
     }
@@ -955,20 +1027,25 @@ export default class CreateOfferForm extends Vue {
             this.pendingOffer = {
                 interestRateNominator: bintools
                     .fromBufferToBN(offer.getInterestRateNominator())
+                    .div(new BN(10000))
                     .toString(10),
                 minAmount: bnToBig(bintools.fromBufferToBN(offer.getMinAmount()), 9).toString(),
                 totalMaxAmount: bnToBig(
                     bintools.fromBufferToBN(offer.getTotalMaxAmount()),
                     9
                 ).toString(),
-                minDuration: Number(bnToBig(bintools.fromBufferToBN(offer.getMinDuration()))),
-                maxDuration: Number(bnToBig(bintools.fromBufferToBN(offer.getMaxDuration()))),
-                unlockPeriodDuration: Number(
-                    bnToBig(bintools.fromBufferToBN(offer.getUnlockPeriodDuration()))
-                ),
-                noRewardsPeriodDuration: Number(
-                    bnToBig(bintools.fromBufferToBN(offer.getNoRewardsPeriodDuration()))
-                ),
+                minDuration:
+                    Number(bnToBig(bintools.fromBufferToBN(offer.getMinDuration()))) /
+                    (24 * 60 * 60),
+                maxDuration:
+                    Number(bnToBig(bintools.fromBufferToBN(offer.getMaxDuration()))) /
+                    (24 * 60 * 60),
+                unlockPeriodDuration:
+                    Number(bnToBig(bintools.fromBufferToBN(offer.getUnlockPeriodDuration()))) /
+                    (24 * 60 * 60),
+                noRewardsPeriodDuration:
+                    Number(bnToBig(bintools.fromBufferToBN(offer.getNoRewardsPeriodDuration()))) /
+                    (24 * 60 * 60),
                 flags: bintools.fromBufferToBN(offer.getFlags()).toString(10),
                 totalMaxRewardAmount: bintools.fromBufferToBN(offer.getTotalMaxRewardAmount()),
                 memo: offer.getMemo().toString(),
@@ -980,6 +1057,7 @@ export default class CreateOfferForm extends Vue {
                     Number(bnToBig(bintools.fromBufferToBN(offer.getEnd()))) * 1000
                 ).toISOString(),
             }
+            this.selectedTab = this.pendingOffer.totalMaxAmount === '0' ? 1 : 0
             if (this.pendingOffer.ownerAddress === ava.PChain().addressFromBuffer(Buffer.alloc(20)))
                 this.pendingOffer.ownerAddress = ''
         }
@@ -1042,6 +1120,9 @@ export default class CreateOfferForm extends Vue {
             display: flex;
             flex-wrap: wrap;
         }
+    }
+    .v-window {
+        overflow: visible;
     }
 }
 </style>

--- a/src/components/wallet/earn/DepositOffers.vue
+++ b/src/components/wallet/earn/DepositOffers.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <h1 class="create-offer-header" v-if="isSuite">Create new DepositOffer</h1>
-        <h4 v-if="isSuite || hasOffers" class="balance">
+        <h4 v-if="!isSuite && hasOffers" class="balance">
             {{ $t('earn.offer.balance') }}: {{ cleanAvaxBN(maxDepositAmount) }}
             {{ nativeAssetSymbol }}
         </h4>
@@ -31,7 +31,7 @@
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 
 import CreateOfferForm from '@/components/wallet/earn/CreateOfferForm.vue'
 import DepositForm from '@/components/wallet/earn/DepositForm.vue'
@@ -56,11 +56,18 @@ import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm/interfa
 })
 export default class DepositOffers extends Vue {
     @Prop() isSuite?: boolean
+    @Prop() navigate?: (path: string) => void
+
+    // @ts-ignore
     helpers = this.globalHelper()
     async beforeMount() {
         if (this.isSuite) {
             this.addOffer()
         }
+    }
+    @Watch('canAddOffers')
+    checkNetwork() {
+        if (this.navigate && !this.canAddOffers) this.navigate('/')
     }
 
     get platformOffers(): DepositOffer[] {

--- a/src/components/wallet/earn/ModalDepositFunds.vue
+++ b/src/components/wallet/earn/ModalDepositFunds.vue
@@ -79,7 +79,7 @@
                                     </span>
                                 </div>
                                 <!-- <span v-if="rewardOwner">{{ rewardOwner }}</span> -->
-                                <div class="deposit_inputs__element">
+                                <!-- <div class="deposit_inputs__element">
                                     <label>Reward Owner</label>
                                     <CamInput
                                         :placeholder="`Rewrad Owner`"
@@ -87,6 +87,17 @@
                                         class="reward-input"
                                         :error="rewardOwnerError"
                                         :errorMessage="rewardOwnerError"
+                                        style="flex: 1"
+                                    />
+                                </div> -->
+                                <div class="deposit_inputs__element">
+                                    <label>Deposit Owner</label>
+                                    <CamInput
+                                        :placeholder="`Deposit Owner`"
+                                        v-model="depositOwner"
+                                        class="reward-input"
+                                        :error="depositOwnerError"
+                                        :errorMessage="depositOwnerError"
                                         style="flex: 1"
                                     />
                                 </div>
@@ -246,15 +257,16 @@ export default class ModalDepositFunds extends Vue {
     rewardOwner: string = ''
     depositOwner: string = ''
     rewardOwnerError: string = ''
+    depositOwnerError: string = ''
 
     $refs!: {
         modal: Modal
         modal_abort_signing: ModalAbortSigning
     }
 
-    @Watch('rewardOwner')
-    onRewardOwnerChange() {
-        this.rewardOwnerError = isValidPChainAddress(this.rewardOwner) ? '' : 'Invalid address'
+    @Watch('depositOwner')
+    onDepositOwnerChange() {
+        this.depositOwnerError = isValidPChainAddress(this.depositOwner) ? '' : 'Invalid address'
     }
     get activeWallet(): MultisigWallet {
         return this.$store.state.activeWallet
@@ -400,10 +412,10 @@ export default class ModalDepositFunds extends Vue {
         return `${(Number(val.toString()) / Number(ONEAVAX.toString())).toLocaleString()}`
     }
     async submitDeposit(): Promise<void> {
-        if (this.rewardOwner && !isValidPChainAddress(this.rewardOwner)) {
-            this.rewardOwnerError = 'Invalid address'
+        if (this.depositOwner && !isValidPChainAddress(this.depositOwner)) {
+            this.depositOwnerError = 'Invalid address'
             return
-        } else this.rewardOwnerError = ''
+        } else this.depositOwnerError = ''
         const wallet: WalletType = this.$store.state.activeWallet
         try {
             const result = await WalletHelper.buildDepositTx(
@@ -413,11 +425,10 @@ export default class ModalDepositFunds extends Vue {
                 this.amt,
                 this.$store.getters['Platform/isDepositOfferRestricted'](this.offer.id),
                 this.offer.ownerAddress,
-                this.rewardOwner,
-                this.depositOwner
+                this.depositOwner,
+                this.rewardOwner
             )
             let { dispatchNotification } = this.helpers
-            this.rewardOwner = ''
             await this.$store.dispatch('Assets/updateUTXOs')
             await this.$store.dispatch('Platform/update')
             dispatchNotification({
@@ -508,6 +519,7 @@ export default class ModalDepositFunds extends Vue {
     }
     cancelDeposit() {
         this.$emit('closeDepositFundsModal')
+        this.depositOwner = ''
     }
     formatDate(date: BN): string {
         const jsDate = new Date(date.toNumber() * 1000)

--- a/src/components/wallet/earn/mountCreateOfferForm.ts
+++ b/src/components/wallet/earn/mountCreateOfferForm.ts
@@ -14,7 +14,10 @@ import DepositOffer from './DepositOffers.vue'
 Vue.use(VueMeta)
 Vue.use(BootstrapVue)
 Vue.component('datetime', Datetime)
-export const mountCreateOfferForm = (el: string, props?: { isSuite: boolean }) => {
+export const mountCreateOfferForm = (
+    el: string,
+    props?: { isSuite: boolean; navigate: (path: string) => {} }
+) => {
     const context = {
         props: props,
     }

--- a/src/explorer_api.ts
+++ b/src/explorer_api.ts
@@ -106,16 +106,21 @@ async function getAliasChains() {
 }
 
 async function getMultisigAliases(ownersAddresses: string[]): Promise<string[]> {
-    let res = await explorer_api.get(`/v2/multisigalias/${ownersAddresses.join(',')}`)
-    return res.data.alias
+    try {
+        let res = await explorer_api.get(`/v2/multisigalias/${ownersAddresses.join(',')}`)
+        return res.data.alias
+    } catch (e) {
+        console.log(e)
+        return []
+    }
 }
 
 export {
     explorer_api,
-    getAddressHistory,
-    getAddressDetailX,
-    isAddressUsedX,
     getAddressChains,
+    getAddressDetailX,
+    getAddressHistory,
     getAliasChains,
     getMultisigAliases,
+    isAddressUsedX,
 }

--- a/src/helpers/wallet_helper.ts
+++ b/src/helpers/wallet_helper.ts
@@ -593,13 +593,13 @@ class WalletHelper {
         depositAmount: BN,
         restrictedOffer?: ModelDepositOfferSig,
         depositOfferOwner?: string,
-        rewardOwner?: string,
-        depositOwner?: string
+        depositOwner?: string,
+        rewardOwner?: string
     ) {
         const pAddressStrings = wallet.getAllAddressesP()
         const signerAddresses = wallet.getSignerAddresses('P')
         const depositOwnerAddress = bintools.parseAddress(
-            rewardOwner ? rewardOwner : wallet.getPlatformRewardAddress(),
+            depositOwner ? depositOwner : wallet.getPlatformRewardAddress(),
             'P'
         )
 
@@ -628,8 +628,8 @@ class WalletHelper {
                 ZeroBN,
                 depositAmount,
                 1,
-                rewardOwner ? [bintools.parseAddress(rewardOwner as string, 'P')] : [],
-                rewardOwner ? 1 : 0
+                depositOwner ? [bintools.parseAddress(depositOwner as string, 'P')] : [],
+                depositOwner ? 1 : 0
             )
         let tx = await wallet.signP(unsignedTx)
         return await ava.PChain().issueTx(tx)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -492,10 +492,25 @@
             "earn_now": {
                 "title": "Saving Pools"
             },
+            "descriptions": {
+                "title": "The title of the deposit offer shown in the Wallet earn section.",
+                "offer_start": "Start-time at which this offer becomes available to be used to deposit funds.",
+                "offer_end": "End-time at which this offer becomes unavailable.",
+                "min_amount": "Minimum amount that can be deposited in one deposit.",
+                "max_amount": "Maximum amount that can be deposited with this offer in total (across all deposits).",
+                "interest_rate": "Annual reward of the deposited funds in percent.",
+                "total_max_reward_amount": "Maximum amount that can be rewarded for all deposits created with this offer in total",
+                "minimum_duration": "The minimum duration which can be picked when creating a deposit based on this offer. In most cases this is identical to 'Maximum Duration' - especially in combination with 'Vesting period' and/or 'Period without rewards' this field should not be different to 'Maximum Duration'.",
+                "maximum_duration": "The maximum duration which can be picked when creating a deposit based on this offer.",
+                "vesting_period": "The period of time in which a gradual undeposit of the tokens is happening. This duration is inside the duration of the deposit at the end. For instance, a deposit of 100 days and 10 days in this field will apply starting at day 90 of the deposit.",
+                "period_without_rewards": "The period of time in which no rewards are being accumulated. This duration is inside the duration of the deposit at the end. For instance, a deposit of 100 days and 10 days in this field will apply starting at day 90 of the deposit.",
+                "Flags": "",
+                "restricted": "If selected, only allowed addresses can see this deposit offer in the Wallet and use it to deposit funds. Caution: If the deposit offer is not restricted, everyone on the network can use it to deposit funds!"
+            },
             "create": {
                 "offer_start": "Offer Start",
                 "offer_end": "Offer End",
-                "interrest_rate": "Interrest rate ( *1 000 000 )",
+                "interrest_rate": "Interest rate",
                 "min_amount": "Min Amount",
                 "total_max_amount": "Total Max Amount",
                 "min_duration": "Minimum Duration (Day)",
@@ -509,7 +524,7 @@
                 "submit": "Create Offer"
             },
             "errors": {
-                "title": "Offer title should not exceed 64 characters.",
+                "title": "Offer title should not exceed 256 characters.",
                 "min_amount": "Minimum amount must be at least {minAmount} {symbol}."
             },
             "offer": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -525,7 +525,14 @@
             },
             "errors": {
                 "title": "Offer title should not exceed 256 characters.",
-                "min_amount": "Minimum amount must be at least {minAmount} {symbol}."
+                "min_amount": "Minimum amount must be at least {minAmount} {symbol}.",
+                "has_exclusive_total_max_amount_or_reward": "can only use either TotalMaxAmount or TotalMaxRewardAmount",
+                "is_max_reward_amount_and_interest_rate_is_zero": "Interest rate must be 0 if total max reward amount is 0, and vice versa",
+                "is_min_duration_less_than_no_rewards_period": "deposit offer minimum duration ({minDuration}) is less than no-rewards period duration ({noRewardsPeriodDuration})",
+                "is_min_duration_less_than_unlock_period": "deposit offer minimum duration ({minDuration}) is less than vesting period duration ({unlockPeriodDuration})",
+                "is_max_diration_less_than_min_duration": "deposit offer max duration ({maxDuration}) is less than minimum duration ({minDuration})",
+                "is_min_duration_equal_to_zero": "deposit offer has zero minimum duration",
+                "is_start_date_greater_than_end_date": " deposit offer start date is greater than end date"
             },
             "offer": {
                 "title": "Active Saving Pools",


### PR DESCRIPTION
### Enhanced PR for Deposit Offer Feature
- Interest Rate Calculation:
 Users can now input the interest rate as a percentage, and the platform will handle the intricate calculations in the background, ensuring accuracy and ease of use.
- Flexibility in Display:
 Enhancing user experience, the total max amount and the combination of interest rate with the total max reward amount can now be seamlessly switched. A user-friendly inline tab allows for easy toggling between "Total Max Amount" and the dual fields of "Interest Rate" + "Total Max Reward Amount."
- Unlock Duration and No Reward Duration:
Clarifying the functionality, the unlock duration and no-reward duration now explicitly relate to the end of the deposit offer period. For instance, if the deposit offer spans 100 days and the unlock/no-reward duration is set at 10 days, the impact will be felt from day 90 of the deposit.
- Owner Address Management:
To streamline the frontend experience, a "Restricted" checkbox has been introduced for whitelisting. The whitelist functionality is only visible when the "Restricted" option is selected. The owner address, critical for whitelist management, now explicitly specifies which address is authorized to add addresses to the whitelist.
- Deposit Owner Address Clarification:
In the deposit funds modal, a correction has been made to accurately label the entity as the "Deposit Owner" instead of the previously mentioned "Reward Owner," providing clarity on the ownership structure.
- Network Compatibility Check:
Users attempting to create offers on a new network will now be seamlessly navigated from the foundation route to the landing page if their address is not permitted to create offers on that network. This enhancement ensures a smoother experience and prevents potential errors.