### PR TITLE
Fix claim rewards reactivity

### DIFF
--- a/src/components/wallet/earn/UserRewards.vue
+++ b/src/components/wallet/earn/UserRewards.vue
@@ -1,12 +1,12 @@
 <template>
     <div v-if="hasRewards">
-        <div class="claimables">
+        <!-- <div class="claimables">
             <ClaimableRewardCard
                 v-for="(v, i) in platformRewards.treasuryRewards"
                 :key="'c' + i"
                 :reward="v"
             ></ClaimableRewardCard>
-        </div>
+        </div> -->
         <div class="user_offers">
             <DepositRewardCard
                 v-for="(v, i) in platformRewards.depositRewards"

--- a/src/components/wallet/earn/Validate/ClaimRewards.vue
+++ b/src/components/wallet/earn/Validate/ClaimRewards.vue
@@ -74,9 +74,8 @@ export default class ClaimRewards extends Vue {
     @Prop() rewardAmount: BN = new BN(0)
     @Prop() pChainddress: string = ''
     @Prop() isMultisignTx: boolean = false
-
-    loading: boolean = false
-    pendingTx: any = undefined
+    @Prop() loading: boolean = false
+    @Prop() pendingTx: any = undefined
 
     get symbol(): string {
         return this.$store.getters['Assets/AssetAVA']?.symbol ?? ''

--- a/src/components/wallet/earn/Validate/ClaimRewards.vue
+++ b/src/components/wallet/earn/Validate/ClaimRewards.vue
@@ -51,16 +51,13 @@ import 'reflect-metadata'
 import { Vue, Component, Prop } from 'vue-property-decorator'
 import ModalClaimReward from './ModalClaimReward.vue'
 import { ValidatorRaw } from '@/components/misc/ValidatorList/types'
-import { WalletHelper } from '../../../../helpers/wallet_helper'
 import { BN } from '@c4tplatform/caminojs'
 import AvaAsset from '@/js/AvaAsset'
 import Big from 'big.js'
-import { MultisigWallet } from '@/js/wallets/MultisigWallet'
 import PendingMultisig from './PendingMultisig.vue'
 import Spinner from '@/components/misc/Spinner.vue'
 import { ava } from '@/AVA'
 import { bnToBigAvaxX } from '@/helpers/helper'
-import { WalletType } from '@/js/wallets/types'
 import CamBtn from '@/components/CamBtn.vue'
 
 @Component({
@@ -74,11 +71,11 @@ import CamBtn from '@/components/CamBtn.vue'
 export default class ClaimRewards extends Vue {
     @Prop() nodeId!: string
     @Prop() nodeInfo!: ValidatorRaw
+    @Prop() rewardAmount: BN = new BN(0)
+    @Prop() pChainddress: string = ''
+    @Prop() isMultisignTx: boolean = false
 
-    rewardAmount: BN = new BN(0)
     loading: boolean = false
-    pChainddress: string = ''
-    isMultisignTx: boolean = false
     pendingTx: any = undefined
 
     get symbol(): string {

--- a/src/components/wallet/earn/Validate/PendingMultisig.vue
+++ b/src/components/wallet/earn/Validate/PendingMultisig.vue
@@ -125,7 +125,7 @@
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 import Spinner from '@/components/misc/Spinner.vue'
 import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
 import { MultisigWallet } from '@/js/wallets/MultisigWallet'
@@ -328,6 +328,7 @@ export default class PendingMultisig extends Vue {
         return !!this.activeWallet.wallets.find((w) => w?.getAllAddressesP()?.[0] === pAddress)
     }
 
+    @Watch('pendingTx')
     refresh() {
         this.$emit('refresh')
     }

--- a/src/components/wallet/earn/Validate/PendingMultisig.vue
+++ b/src/components/wallet/earn/Validate/PendingMultisig.vue
@@ -4,6 +4,12 @@
         <div class="container">
             <div v-if="!!claimTxDetails" class="transaction_details">
                 <h4>{{ $t('validator.transaction_reward.title') }}</h4>
+                <div>
+                    <label>{{ $t('earn.validate.confirmation.claimed_amount') }}</label>
+                    <p style="word-break: break-all">
+                        {{ claimTxDetails?.claimedAmount }} {{ nativeAssetSymbol }}
+                    </p>
+                </div>
                 <div v-if="claimTxDetails?.nodeId">
                     <label>{{ $t('earn.validate.confirmation.id') }}</label>
                     <p style="word-break: break-all">{{ claimTxDetails?.nodeId }}</p>
@@ -129,7 +135,6 @@ import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 import Spinner from '@/components/misc/Spinner.vue'
 import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
 import { MultisigWallet } from '@/js/wallets/MultisigWallet'
-import { Buffer } from '@c4tplatform/caminojs/dist'
 import { UnsignedTx, AddValidatorTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
 import Big from 'big.js'
 import { ValidatorRaw } from '@/components/misc/ValidatorList/types'
@@ -137,6 +142,9 @@ import moment from 'moment'
 import ModalAbortSigning from '../ModalAbortSigning.vue'
 import CamBtn from '@/components/CamBtn.vue'
 import Alert from '@/components/Alert.vue'
+import { ClaimTx } from '@c4tplatform/caminojs/dist/apis/platformvm/claimtx'
+import { bnToBig } from '@/helpers/helper'
+import { BN, Buffer } from '@c4tplatform/caminojs'
 
 @Component({
     components: {
@@ -219,7 +227,7 @@ export default class PendingMultisig extends Vue {
     get claimTxDetails() {
         let unsignedTx = new UnsignedTx()
         unsignedTx.fromBuffer(Buffer.from(this.multisigTx?.tx?.unsignedTx, 'hex'))
-        const utx = unsignedTx.getTransaction()
+        const utx = unsignedTx.getTransaction() as ClaimTx
         if (
             utx?.getTypeName() === 'ClaimTx' &&
             this.nodeInfo !== undefined &&
@@ -239,6 +247,10 @@ export default class PendingMultisig extends Vue {
                     ? moment(new Date(this.multisigTx.tx.timestamp)).format('DD/MM/YYYY')
                     : ''
 
+            const claimAmounts = utx.getClaimAmounts()
+            const amount = claimAmounts[0].getAmount()
+            const claimedAmount = bnToBig(new BN(amount), 9)?.toLocaleString()
+
             return {
                 nodeId: this.nodeId,
                 from: this.nodeInfo.rewardOwner.addresses[0],
@@ -246,6 +258,7 @@ export default class PendingMultisig extends Vue {
                 startDate: dateTimeStart,
                 endDate: dateTimeEnd,
                 stakeAmount: parseFloat(this.nodeInfo.stakeAmount) / 1000000000,
+                claimedAmount: claimedAmount,
             }
         }
 

--- a/src/components/wallet/earn/Validate/PendingMultisig.vue
+++ b/src/components/wallet/earn/Validate/PendingMultisig.vue
@@ -4,7 +4,7 @@
         <div class="container">
             <div v-if="!!claimTxDetails" class="transaction_details">
                 <h4>{{ $t('validator.transaction_reward.title') }}</h4>
-                <div>
+                <div v-if="claimTxDetails?.claimedAmount">
                     <label>{{ $t('earn.validate.confirmation.claimed_amount') }}</label>
                     <p style="word-break: break-all">
                         {{ claimTxDetails?.claimedAmount }} {{ nativeAssetSymbol }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -659,7 +659,8 @@
                 "reward": "Reward Address",
                 "type_local": "This wallet",
                 "type_custom": "Custom",
-                "transaction_end": "Transaction Expiration Date"
+                "transaction_end": "Transaction Expiration Date",
+                "claimed_amount": "Claimed Amount"
             },
             "register_validator_node": "Register Validator Node",
             "initiate_transaction": "Initiate Transaction",

--- a/src/views/wallet/Validator.vue
+++ b/src/views/wallet/Validator.vue
@@ -118,6 +118,7 @@
                             @refresh="refresh"
                             @getClaimableReward="getClaimableReward"
                             @getPendingTransaction="getPendingTransaction"
+                            @getPChainAddress="getPChainAddress"
                         />
                     </div>
                     <div v-else>
@@ -393,6 +394,7 @@ export default class Validator extends Vue {
     async refresh() {
         if (this.tab == 'opt-rewards') {
             this.loading = true
+            await this.$store.dispatch('Signavault/updateTransaction')
             await this.getClaimableReward()
             await this.getPChainAddress()
             await this.getPendingTransaction()

--- a/src/views/wallet/Validator.vue
+++ b/src/views/wallet/Validator.vue
@@ -401,6 +401,7 @@ export default class Validator extends Vue {
             this.loadingRefreshRegisterNode = true
             this.loading = true
             this.$store.dispatch('updateBalances')
+            if (this.isMultisignTx) await this.getPendingTransaction()
             await this.evaluateCanRegisterNode()
             await this.updateValidators()
             await this.$store.dispatch('Signavault/updateTransaction')

--- a/src/views/wallet/Validator.vue
+++ b/src/views/wallet/Validator.vue
@@ -392,7 +392,11 @@ export default class Validator extends Vue {
 
     async refresh() {
         if (this.tab == 'opt-rewards') {
+            this.loading = true
             await this.getClaimableReward()
+            await this.getPChainAddress()
+            await this.getPendingTransaction()
+            this.loading = false
         } else {
             if (this.multisigPendingNodeTx) {
                 await this.$store.dispatch('Signavault/updateTransaction')

--- a/src/views/wallet/Validator.vue
+++ b/src/views/wallet/Validator.vue
@@ -113,6 +113,8 @@
                             :rewardAmount="rewardAmount"
                             :pChainddress="pChainddress"
                             :isMultisignTx="isMultisignTx"
+                            :pendingTx="pendingTx"
+                            :loading="loading"
                             @refresh="refresh"
                             @getClaimableReward="getClaimableReward"
                             @getPendingTransaction="getPendingTransaction"


### PR DESCRIPTION
## Pull Request Description

### Summary of Changes

This pull request introduces several updates and fixes to the rewards claiming features in our application. The main changes are as follows:

1. **Removal of Claim Validator Rewards from the Earn Section:** 
   - The claim validator rewards feature has been removed from the Earn section. This decision was made because the feature is already available and more appropriately placed in the Validator section.

2. **Fix Refresh Button Issues in Claim Rewards of the Validator Section:**
   - Addressed and resolved issues related to the refresh button in the Claim Rewards section of the Validator area. Previously, users might have encountered difficulties or inconsistencies when attempting to refresh their claim rewards status.

3. **Added Claimed Amount in Transaction Info for Multi-Signature Wallet in Claim Rewards:**
   - Introduced a new feature that displays the claimed amount in the transaction information for claims made through multi-signature wallets. 

4. **Fix for Missing Props in Claim Rewards Component:**
   - Resolved an issue where necessary props were not being passed to the Claim Rewards component. This oversight may have led to incomplete or erroneous display of information.