### PR TITLE
add access wallet with keyEnter press

### DIFF
--- a/src/components/misc/MnemonicInput.vue
+++ b/src/components/misc/MnemonicInput.vue
@@ -12,6 +12,7 @@
                     v-model="phrase[i - 1]"
                     @input="onChange(i - 1)"
                     :data-cy="getDataCY(i)"
+                    @keyup.enter="onEnterKey"
                 />
             </div>
         </div>
@@ -31,8 +32,8 @@
     </div>
 </template>
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator'
 import { wordlists } from 'bip39'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
 @Component
 export default class MnemonicDisplay extends Vue {
@@ -57,6 +58,9 @@ export default class MnemonicDisplay extends Vue {
         if (!(wordlists.EN.includes(word) || !word)) ret = ret + ' invalid_input'
         if (!this.password && this.isHidden) ret = ret + ' pass'
         return ret
+    }
+    onEnterKey() {
+        this.$emit('access')
     }
 
     onChange(i: number) {

--- a/src/views/access/Account.vue
+++ b/src/views/access/Account.vue
@@ -13,6 +13,7 @@
                 />
                 <p class="err">{{ error }}</p>
                 <CamBtn
+                    type="submit"
                     variant="primary"
                     style="width: 100%"
                     @click="access"
@@ -28,11 +29,11 @@
     </div>
 </template>
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator'
-import { ImportKeyfileInput } from '@/store/types'
-import Identicon from '@/components/misc/Identicon.vue'
 import CamBtn from '@/components/CamBtn.vue'
 import CamInput from '@/components/CamInput.vue'
+import Identicon from '@/components/misc/Identicon.vue'
+import { ImportKeyfileInput } from '@/store/types'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
 @Component({
     components: { Identicon, CamBtn, CamInput },

--- a/src/views/access/Mnemonic.vue
+++ b/src/views/access/Mnemonic.vue
@@ -8,6 +8,7 @@
             :phrase="phrase.split(' ')"
             class="phrase_disp"
             @update="mnemonicUpdate($event)"
+            @access="access"
         />
         <div class="button_container">
             <p class="err" v-if="err">{{ err }}</p>
@@ -28,12 +29,12 @@
 </template>
 <script lang="ts">
 import 'reflect-metadata'
-import { Vue, Component, Prop } from 'vue-property-decorator'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
-import MnemonicDisplay from '@/components/misc/MnemonicDisplay.vue'
-import * as bip39 from 'bip39'
-import MnemonicInput from '@/components/misc/MnemonicInput.vue'
 import CamBtn from '@/components/CamBtn.vue'
+import MnemonicDisplay from '@/components/misc/MnemonicDisplay.vue'
+import MnemonicInput from '@/components/misc/MnemonicInput.vue'
+import * as bip39 from 'bip39'
 
 @Component({
     components: {
@@ -89,6 +90,7 @@ export default class Mnemonic extends Vue {
     }
 
     async access() {
+        if (!this.canSubmit) return
         this.phrase = this.phrase.trim()
         let phrase = this.phrase
 

--- a/src/views/access/PrivateKey.vue
+++ b/src/views/access/PrivateKey.vue
@@ -12,9 +12,9 @@
                 ></cam-input>
                 <p class="err">{{ error }}</p>
                 <CamBtn
+                    type="submit"
                     variant="primary"
                     style="width: 100%"
-                    :type="`button`"
                     @click="access"
                     :loading="isLoading"
                     :disabled="!canSubmit"
@@ -28,9 +28,9 @@
     </div>
 </template>
 <script lang="ts">
-import { Vue, Component, Prop } from 'vue-property-decorator'
 import CamBtn from '@/components/CamBtn.vue'
 import CamInput from '@/components/CamInput.vue'
+import { Component, Prop, Vue } from 'vue-property-decorator'
 
 @Component({
     components: {


### PR DESCRIPTION
This pull request addresses an issue where pressing the Enter key while entering the password did not trigger the expected action. Previously, users were required to manually click the "ACCESS WALLET" button instead of being able to submit the form using the Enter key.

The problem has been resolved by adding a key event listener to the password input field. Now, when users input their password and press the Enter key, the form submission action is triggered automatically, providing a more seamless and intuitive user experience.

This enhancement improves the accessibility and usability of the password entry process, eliminating the need for users to rely solely on mouse interactions for form submission.