### PR TITLE
fix(login): update outdated MSIG definition during login

### DIFF
--- a/src/js/wallets/MultisigWallet.ts
+++ b/src/js/wallets/MultisigWallet.ts
@@ -104,16 +104,17 @@ class MultisigWallet extends WalletCore implements AvaWalletCore {
         return JSON.stringify(this.keyData)
     }
 
-    setKey(key?: string, updatedValues?: { addresses: string[]; threshold: number }): void {
-        if (updatedValues) {
-            this.keyData.owner.addresses = updatedValues.addresses
-            this.keyData.owner.threshold = updatedValues.threshold
-        } else if (key) {
+    async setKey(key?: string): Promise<void> {
+        let hrp = ava.getHRP()
+        if (key) {
             this.keyData = JSON.parse(key)
-            // The JSON buffer is not our "AvalancheBuffer"
             this.keyData.alias = Buffer.from(this.keyData.alias)
             this.ethAddress = this.keyData.alias.toString('hex')
         }
+        let alias = bintools.addressToString(hrp, 'P', this.keyData.alias)
+        let values = await ava.PChain().getMultisigAlias(alias)
+        this.keyData.owner.addresses = values.addresses
+        this.keyData.owner.threshold = values.threshold
     }
 
     ownerAddresses(): Buffer[] {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -325,7 +325,7 @@ export default new Vuex.Store({
                 const wallet = new MultisigWallet()
                 if (file.name) wallet.name = file.name
                 wallet.accountHash = createHash('sha256').update(file.key).digest()
-                wallet.setKey(file.key)
+                await wallet.setKey(file.key)
                 state.wallets = [...state.wallets, wallet]
                 state.volatileWallets = [...state.volatileWallets, wallet]
                 return [wallet]

--- a/src/views/EditMultisigWallet.vue
+++ b/src/views/EditMultisigWallet.vue
@@ -164,6 +164,8 @@ import Alert from '@/components/Alert.vue'
 import CamBtn from '@/components/CamBtn.vue'
 import CamInput from '@/components/CamInput.vue'
 import CamTooltip from '@/components/misc/CamTooltip.vue'
+import { getMultisigAliases } from '@/explorer_api'
+import { isValidPChainAddress } from '@/helpers/address_helper'
 import AvaAsset from '@/js/AvaAsset'
 import { AvaNetwork } from '@/js/AvaNetwork'
 import { MultisigWallet } from '@/js/wallets/MultisigWallet'
@@ -176,11 +178,9 @@ import { MultisigAliasTx } from '@c4tplatform/caminojs/dist/apis/platformvm/mult
 import { SignatureError } from '@c4tplatform/caminojs/dist/common'
 import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
 import { ModelMultisigTxOwner } from '@c4tplatform/signavaultjs'
+import { TranslateResult } from 'vue-i18n'
 import { Component, Vue, Watch } from 'vue-property-decorator'
 import { WalletHelper } from '../helpers/wallet_helper'
-import { TranslateResult } from 'vue-i18n'
-import { isValidPChainAddress } from '@/helpers/address_helper'
-import { getMultisigAliases } from '@/explorer_api'
 
 const MAX_ADDRESS_COUNT = 128
 const UPDATE_ALIAS_TIMEOUT = 3000
@@ -509,10 +509,7 @@ export default class EditMultisigWallet extends Vue {
                 this.loading = true
                 let values = await ava.PChain().getMultisigAlias(alias)
                 let wallet = this.activeWallet as MultisigWallet
-                wallet.setKey(undefined, {
-                    addresses: values.addresses,
-                    threshold: values.threshold,
-                })
+                await wallet.setKey()
                 const result = await WalletHelper.sendMultisigAliasTxUpdate(
                     this.activeWallet as MultisigWallet,
                     nonEmptyInitialAddresses,


### PR DESCRIPTION
## Description

This PR fixes an issue where outdated MSIG definitions were not updated during login with an MSIG wallet. It ensures that MSIG definitions are updated according to the latest definitions from Magellan when logging in with an MSIG wallet.