### PR TITLE
Notify Users When Reward Amount is Less Than Transaction Fee

### DIFF
--- a/src/components/wallet/earn/ModalClaimDepositReward.vue
+++ b/src/components/wallet/earn/ModalClaimDepositReward.vue
@@ -25,6 +25,9 @@
                         }}
                     </p>
                 </div>
+                <Alert variant="warning" v-if="isAmountLessThanTxFee">
+                    {{ $t('earn.rewards.claim_modal.alert_info_message') }}
+                </Alert>
                 <div class="modal-buttons">
                     <CamBtn variant="transparent" @click="close()">
                         {{ $t('earn.rewards.claim_modal.cancel') }}
@@ -78,12 +81,14 @@ import Modal from '../../modals/Modal.vue'
 import CamBtn from '@/components/CamBtn.vue'
 import { cleanAvaxBN } from '@/helpers/helper'
 import { ZeroBN } from '@/constants'
+import Alert from '@/components/Alert.vue'
 
 @Component({
     components: {
         AvaxInput,
         Modal,
         CamBtn,
+        Alert,
     },
 })
 export default class ModalClaimDepositReward extends Vue {
@@ -138,7 +143,11 @@ export default class ModalClaimDepositReward extends Vue {
     }
 
     get feeAmt(): string {
-        return this.formattedAmount(ava.PChain().getTxFee())
+        return this.cleanAvaxBN(ava.PChain().getTxFee())
+    }
+
+    get isAmountLessThanTxFee(): boolean {
+        return this.amt.lt(ava.PChain().getTxFee())
     }
 
     get ava_asset(): AvaAsset | null {

--- a/src/components/wallet/earn/UserRewards.vue
+++ b/src/components/wallet/earn/UserRewards.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="hasPendingRewards || hasRewards">
         <TreasuryRewardCard
-            v-if="firstTreasuryReward"
+            v-if="firstTreasuryReward && !firstTreasuryReward.amountToClaim.isZero()"
             class="reward_card"
             :key="'reward_TreasuryReward'"
             :reward="firstTreasuryReward"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -593,7 +593,8 @@
                 "confirmation_message": "{amount} {symbol} has been claimed.",
                 "signature_collected": "Your signature has been collected.",
                 "confirm": "Confirm",
-                "cancel": "Cancel"
+                "cancel": "Cancel",
+                "alert_info_message": "The requested claim operation will claim less funds than the transaction will cost. Please confirm that you want to proceed with this operation."
             },
             "abort_modal": {
                 "title": "Abort Claim Rewards",


### PR DESCRIPTION
## Description
This PR addresses an issue where users are not notified when their pending rewards are less than the transaction fee. Previously, if the reward amount was smaller than the fee, the difference was automatically deducted from their balance without warning, leading to potential confusion and frustration.

<img width="601" alt="Screenshot 2024-09-10 at 19 06 58" src="https://github.com/user-attachments/assets/1965d6bc-bf57-4046-bc50-dc3b9d8a4fad">