### PR TITLE
Fix: Adjust buildRegisterNode Parameters and Resolve Restricted Offers Issue with Multisig Wallets

### DIFF
--- a/src/components/wallet/earn/CreateOfferForm.vue
+++ b/src/components/wallet/earn/CreateOfferForm.vue
@@ -777,7 +777,8 @@ export default class CreateOfferForm extends Vue {
 
     /* methods */
     async submitCreateOffer() {
-        if (!this.isRestricted) this.offer.ownerAddress = undefined
+        if (!this.isRestricted || this.wallet.type === 'multisig')
+            this.offer.ownerAddress = undefined
         else this.offer.ownerAddress = this.wallet?.getStaticAddress('P')
         this.txState = TxState.started
         const wallet: WalletType = this.$store.state.activeWallet
@@ -793,7 +794,12 @@ export default class CreateOfferForm extends Vue {
         try {
             const result = await WalletHelper.buildAddDepositOfferTx(wallet, offer)
             this.txState = TxState.waiting
-            this.waitTxConfirm(result, addresses, this.offer.start.toNumber(), this.isRestricted)
+            this.waitTxConfirm(
+                result,
+                addresses,
+                this.offer.start.toNumber(),
+                this.wallet.type === 'multisig' ? false : this.isRestricted
+            )
         } catch (error) {
             if (error instanceof SignatureError) {
                 await this.$store.dispatch('Signavault/updateTransaction')

--- a/src/helpers/wallet_helper.ts
+++ b/src/helpers/wallet_helper.ts
@@ -278,8 +278,6 @@ class WalletHelper {
 
         const signerAddresses = wallet.getSignerAddresses('P')
 
-        // For change address use first available on the platform chain
-        const changeAddress = wallet.getChangeAddressPlatform()
         const consortiumMemberAuthCredentials: [number, Buffer | string][] = [
             [0, pAddressStrings[0]],
         ]
@@ -290,7 +288,7 @@ class WalletHelper {
         const unsignedTx = await ava.PChain().buildRegisterNodeTx(
             utxoSet,
             [pAddressStrings, signerAddresses], // from + possible signers
-            [changeAddress], // change
+            [], // change
             oldNodeID,
             newNodeID,
             address,
@@ -368,9 +366,6 @@ class WalletHelper {
         const pAddressStrings = wallet.getAllAddressesP()
         const signerAddresses = wallet.getSignerAddresses('P')
 
-        // For change address use first available on the platform chain
-        const changeAddress = wallet.getChangeAddressPlatform()
-
         const threshold =
             wallet.type === 'multisig' ? (wallet as MultisigWallet)?.keyData?.owner?.threshold : 1
 
@@ -379,7 +374,7 @@ class WalletHelper {
             amount,
             [toAddress],
             [pAddressStrings, signerAddresses], // from + possible signers
-            [changeAddress], // change
+            [], // change
             memo,
             undefined, // asOf
             undefined, // lockTime


### PR DESCRIPTION
- **Adjust `buildRegisterNode` parameters:** Updated the function to improve parameter handling and ensure proper integration.  
- **Fix restricted offers with multisig wallets:** Resolved an issue that prevented the creation of restricted offers when using multisig wallets.