### PR TITLE
Feat/unlock deposit transaction support

### DIFF
--- a/src/components/CamOfferCard.vue
+++ b/src/components/CamOfferCard.vue
@@ -82,10 +82,24 @@
                             {{ cleanAvaxBN(reward.deposit.amount) }} {{ nativeAssetSymbol }}
                         </p>
                     </div>
+                    <div>
+                        <label>{{ $t('earn.rewards.active_earning.undepositable_amount') }}:</label>
+                        <p class="reward">
+                            {{ cleanAvaxBN(reward?.deposit?.unlockableAmount) }}
+                            {{ nativeAssetSymbol }}
+                        </p>
+                    </div>
                     <div class="reward_row">
                         <label>{{ $t('earn.rewards.active_earning.pending_reward') }}:</label>
                         <p class="reward">
                             {{ cleanAvaxBN(reward.amountToClaim) }} {{ nativeAssetSymbol }}
+                        </p>
+                    </div>
+                    <div>
+                        <label>{{ $t('earn.rewards.active_earning.already_undeposited') }}:</label>
+                        <p class="reward">
+                            {{ cleanAvaxBN(reward?.deposit?.unlockedAmount) }}
+                            {{ nativeAssetSymbol }}
                         </p>
                     </div>
                     <div class="reward_row">
@@ -100,6 +114,10 @@
                         <p class="reward">
                             {{ updateMultisigTxDetails() }} {{ nativeAssetSymbol }}
                         </p>
+                    </div>
+                    <div class="reward_row" v-if="pendingUnlockAmount !== null">
+                        <label>{{ $t('earn.rewards.active_earning.initiated_undeposit') }}:</label>
+                        <p class="reward">{{ pendingUnlockAmount }} {{ nativeAssetSymbol }}</p>
                     </div>
                 </div>
             </div>
@@ -137,6 +155,7 @@ import { ClaimTx, UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
 import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm/interfaces'
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import CamCard from './CamCard.vue'
+import { bnToBig, UndepositPendingTx } from '@/helpers/helper'
 
 @Component({
     components: { CamCard },
@@ -147,6 +166,7 @@ export default class CamOfferCard extends Vue {
     @Prop() readonly offer!: DepositOffer
     @Prop() readonly reward!: PlatformRewardDeposit
     @Prop() readonly treasuryRewards!: PlatformRewardTreasury
+    @Prop() readonly pendingUndepositTx!: UndepositPendingTx | null
 
     get isOffer() {
         return this.type === 'offer'
@@ -154,6 +174,18 @@ export default class CamOfferCard extends Vue {
 
     get isReward() {
         return this.type === 'reward'
+    }
+
+    get pendingUnlockAmount() {
+        if (
+            this.pendingUndepositTx &&
+            this.pendingUndepositTx.depositTxIDs.find(
+                (id: string) => id === this.reward.deposit.depositTxID
+            )
+        ) {
+            return Number(bnToBig(this.pendingUndepositTx?.amountToUndeposit, 9)?.toString())
+        }
+        return null
     }
 
     get isTreasuryRewards() {

--- a/src/components/wallet/earn/DepositRewardCard.vue
+++ b/src/components/wallet/earn/DepositRewardCard.vue
@@ -97,6 +97,13 @@
             >
                 {{ $t('earn.rewards.active_earning.are_you_sure') }}
             </Alert>
+            <Alert
+                v-if="pendingUndepositTx && !pendingUndepositTx.hasSufficientUnlocked"
+                variant="warning"
+                class="mt-2"
+            >
+                {{ $t('earn.rewards.active_earning.total_to_unlock_check') }}
+            </Alert>
         </template>
         <ModalClaimDepositReward
             ref="modal_claim_reward"
@@ -119,7 +126,7 @@ import 'reflect-metadata'
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 
 import ModalClaimReward from '@/components/modals/ClaimRewardModal.vue'
-import { cleanAvaxBN } from '@/helpers/helper'
+import { cleanAvaxBN, UndepositPendingTx } from '@/helpers/helper'
 import { PlatformRewardDeposit } from '@/store/modules/platform/types'
 
 import { bintools } from '@/AVA'
@@ -162,13 +169,20 @@ export default class DepositRewardCard extends Vue {
     disclaimerDisplay: boolean = false
     // signedDepositID: string = ''
     @Prop() reward!: PlatformRewardDeposit
-    @Prop() pendingUndepositTx!: any
+    @Prop() pendingUndepositTx!: UndepositPendingTx
 
     $refs!: {
         // modal_claim_reward: ModalClaimReward
         modal_claim_reward: ModalClaimDepositReward
         modal_abort_signing: ModalAbortSigning
         modal_undeposit: ModalUndeposit
+    }
+
+    @Watch('pendingUndepositTx')
+    watchPendingTX() {
+        if (this.pendingUndepositTx.pendingTx) {
+            this.disclaimerDisplay = false
+        }
     }
 
     openAbortModal() {

--- a/src/components/wallet/earn/DepositRewardCard.vue
+++ b/src/components/wallet/earn/DepositRewardCard.vue
@@ -1,6 +1,14 @@
 <template>
-    <CamOfferCard :title="rewardTitle" type="reward" :reward="reward">
+    <CamOfferCard
+        :title="rewardTitle"
+        type="reward"
+        :reward="reward"
+        :pendingUndepositTx="pendingUndepositTx"
+    >
         <div v-if="!isMultiSig" class="button_group">
+            <CamBtn variant="primary" @click="openUndepositModal" :disabled="isUndepositDisabled">
+                {{ $t('earn.rewards.active_earning.undeposit') }}
+            </CamBtn>
             <CamBtn variant="primary" @click="openModal" :disabled="isClaimDisabled">
                 {{ $t('earn.rewards.active_earning.claim') }}
             </CamBtn>
@@ -67,6 +75,11 @@
                 </CamBtn>
             </div>
             <div v-else class="button_group">
+                <undeposit-buttons
+                    :reward="reward"
+                    :pendingUndepositTx="pendingUndepositTx"
+                    @updateDisclaimer="updateDisclaimer"
+                />
                 <CamBtn
                     variant="primary"
                     @click="disclamer = true"
@@ -76,7 +89,9 @@
                 </CamBtn>
             </div>
             <Alert
-                v-if="disclamer && !alreadySigned(reward.deposit.depositTxID)"
+                v-if="
+                    (disclamer && !alreadySigned(reward.deposit.depositTxID)) || disclaimerDisplay
+                "
                 variant="warning"
                 class="mt-2"
             >
@@ -121,6 +136,8 @@ import { DepositOffer } from '@c4tplatform/caminojs/dist/apis/platformvm/interfa
 import { ModelMultisigTxOwner } from '@c4tplatform/signavaultjs'
 import ModalAbortSigning from './ModalAbortSigning.vue'
 import ModalClaimDepositReward from './ModalClaimDepositReward.vue'
+import ModalUndeposit from './ModalUndeposit.vue'
+import UndepositButtons from './UndepositButtons.vue'
 
 @Component({
     components: {
@@ -130,6 +147,8 @@ import ModalClaimDepositReward from './ModalClaimDepositReward.vue'
         CamBtn,
         Alert,
         CamOfferCard,
+        ModalUndeposit,
+        UndepositButtons,
     },
 })
 export default class DepositRewardCard extends Vue {
@@ -140,13 +159,16 @@ export default class DepositRewardCard extends Vue {
     // @ts-ignore
     helpers = this.globalHelper()
     signedclaimedAmount: BN = new BN(0)
+    disclaimerDisplay: boolean = false
     // signedDepositID: string = ''
     @Prop() reward!: PlatformRewardDeposit
+    @Prop() pendingUndepositTx!: any
 
     $refs!: {
         // modal_claim_reward: ModalClaimReward
         modal_claim_reward: ModalClaimDepositReward
         modal_abort_signing: ModalAbortSigning
+        modal_undeposit: ModalUndeposit
     }
 
     openAbortModal() {
@@ -154,6 +176,10 @@ export default class DepositRewardCard extends Vue {
     }
     updateNow() {
         this.now = Date.now()
+    }
+
+    updateDisclaimer() {
+        this.disclaimerDisplay = !this.disclaimerDisplay
     }
 
     created() {
@@ -170,11 +196,15 @@ export default class DepositRewardCard extends Vue {
         this.updateMultisigTxDetails()
     }
 
+    get unlockableAmount(): BN {
+        return this.reward.deposit.unlockableAmount
+    }
+
     get activeWallet(): WalletType {
         return this.$store.state.activeWallet
     }
 
-    get pendingSendMultisigTX(): SignavaultTx | undefined {
+    get pendingClaimMultisigTx(): SignavaultTx | undefined {
         return this.$store.getters['Signavault/transactions'].find(
             (item: any) =>
                 item?.tx?.alias === this.activeWallet.getStaticAddress('P') &&
@@ -186,9 +216,9 @@ export default class DepositRewardCard extends Vue {
         const wallet = this.activeWallet
         if (!wallet || !(wallet instanceof MultisigWallet))
             return console.debug('MultiSigTx::sign: Invalid wallet')
-        if (!this.pendingSendMultisigTX) return console.debug('MultiSigTx::sign: Invalid Tx')
+        if (!this.pendingClaimMultisigTx) return console.debug('MultiSigTx::sign: Invalid Tx')
         try {
-            await wallet.addSignatures(this.pendingSendMultisigTX?.tx)
+            await wallet.addSignatures(this.pendingClaimMultisigTx?.tx)
             this.helpers.dispatchNotification({
                 message: this.$t('notifications.multisig_transaction_saved'),
                 type: 'success',
@@ -206,9 +236,9 @@ export default class DepositRewardCard extends Vue {
     async cancelMultisigTx() {
         try {
             const wallet = this.activeWallet as MultisigWallet
-            if (this.pendingSendMultisigTX) {
+            if (this.pendingClaimMultisigTx) {
                 // cancel from the wallet
-                await wallet.cancelExternal(this.pendingSendMultisigTX?.tx)
+                await wallet.cancelExternal(this.pendingClaimMultisigTx?.tx)
                 await this.$store.dispatch('Signavault/updateTransaction')
                 this.helpers.dispatchNotification({
                     message: this.$t('transfer.multisig.transaction_aborted'),
@@ -226,9 +256,9 @@ export default class DepositRewardCard extends Vue {
     }
 
     private async updateMultisigTxDetails() {
-        if (this.pendingSendMultisigTX) {
+        if (this.pendingClaimMultisigTx) {
             let unsignedTx = new UnsignedTx()
-            unsignedTx.fromBuffer(Buffer.from(this.pendingSendMultisigTX.tx?.unsignedTx, 'hex'))
+            unsignedTx.fromBuffer(Buffer.from(this.pendingClaimMultisigTx.tx?.unsignedTx, 'hex'))
             const utx = unsignedTx.getTransaction() as ClaimTx
             const claimAmounts = utx.getClaimAmounts()
 
@@ -236,6 +266,7 @@ export default class DepositRewardCard extends Vue {
             this.signedclaimedAmount = new BN(amount)
         }
     }
+
     get numberOfSignatures(): number {
         let signers = 0
         this.txOwners(this.reward.deposit.depositTxID).forEach((owner) => {
@@ -245,11 +276,11 @@ export default class DepositRewardCard extends Vue {
     }
 
     get threshold(): number {
-        return this.pendingSendMultisigTX?.tx?.threshold ?? 0
+        return this.pendingClaimMultisigTx?.tx?.threshold ?? 0
     }
 
     getPendingMultisigTx(depositTxID: string): SignavaultTx | undefined {
-        const tx = this.pendingSendMultisigTX
+        const tx = this.pendingClaimMultisigTx
         if (!tx) return undefined
 
         const depositId = this.signedDepositID()
@@ -258,7 +289,7 @@ export default class DepositRewardCard extends Vue {
     }
 
     signedDepositID() {
-        const tx = this.pendingSendMultisigTX
+        const tx = this.pendingClaimMultisigTx
 
         if (!tx) return undefined
 
@@ -319,7 +350,7 @@ export default class DepositRewardCard extends Vue {
     }
 
     disallowedClaim(depositTxID: string): boolean {
-        if (!this.pendingSendMultisigTX) return false
+        if (!this.pendingClaimMultisigTx) return false
         else {
             if (!this.signedDepositID() || this.signedDepositID() === depositTxID) return false
             else return true
@@ -341,7 +372,19 @@ export default class DepositRewardCard extends Vue {
     }
 
     get isClaimDisabled() {
-        return this.reward.amountToClaim.isZero()
+        return (
+            this.reward.amountToClaim.isZero() ||
+            (this.$store.getters['Signavault/transactions'].length > 0 &&
+                !this.pendingClaimMultisigTx)
+        )
+    }
+
+    get isUndepositDisabled() {
+        return this.reward.deposit.unlockableAmount.isZero()
+    }
+
+    get initiatedUnlockAmount(): string {
+        return this.pendingUndepositTx.amountToUndeposit
     }
 
     cleanAvaxBN(val: BN): string {
@@ -351,6 +394,11 @@ export default class DepositRewardCard extends Vue {
     openModal() {
         this.disclamer = false
         this.$refs.modal_claim_reward.open()
+    }
+
+    openUndepositModal() {
+        this.disclamer = false
+        this.$refs.modal_undeposit.open()
     }
 }
 </script>

--- a/src/components/wallet/earn/ModalUndeposit.vue
+++ b/src/components/wallet/earn/ModalUndeposit.vue
@@ -1,0 +1,258 @@
+<template>
+    <modal ref="modal" title="Undeposit" @beforeClose="beforeClose">
+        <div class="claim-reward-modal">
+            <div v-if="undeposit === 0">
+                <p class="text--modal">
+                    {{
+                        $t('earn.rewards.active_earning.unlock_amount', {
+                            nativeAssetSymbol: nativeAssetSymbol,
+                        })
+                    }}
+                </p>
+                <br />
+                <div v-if="isMultiSig && canExecuteMultisigTx">
+                    <AvaxInput
+                        v-model="amount"
+                        :initial="amount"
+                        :max="amount"
+                        :readonly="true"
+                    ></AvaxInput>
+                </div>
+                <div v-else-if="isMultiSig && !canExecuteMultisigTx">
+                    <AvaxInput :max="maxUndepositable" v-model="amt"></AvaxInput>
+                </div>
+                <AvaxInput v-else :max="maxUndepositable" v-model="amt"></AvaxInput>
+                <br />
+                <p class="text--modal">
+                    <span style="font-weight: bold">{{ formattedAmount(maxUndepositable) }}</span>
+                    {{
+                        $t('earn.rewards.active_earning.total_to_unlock', {
+                            nativeAssetSymbol: nativeAssetSymbol,
+                        })
+                    }}
+                </p>
+                <div class="modal-buttons">
+                    <CamBtn variant="transparent" @click="close()">
+                        {{ $t('validator.rewards.modal_claim.cancel') }}
+                    </CamBtn>
+                    <CamBtn
+                        variant="primary"
+                        @click="confirmClaim()"
+                        :disabled="amt && amt.isZero()"
+                    >
+                        {{ submitSentence }}
+                    </CamBtn>
+                </div>
+                <br />
+                <Alert variant="info">
+                    {{
+                        $t('earn.rewards.claim_modal.note_message', {
+                            fee: feeAmt,
+                            symbol: nativeAssetSymbol,
+                        })
+                    }}
+                </Alert>
+            </div>
+            <div class="confirmed-claimed" v-else-if="undeposit === 1">
+                <br />
+                <h2>{{ $t('earn.rewards.undeposit_modal.signature_collected') }}</h2>
+                <br />
+            </div>
+        </div>
+    </modal>
+</template>
+<script lang="ts">
+import 'reflect-metadata'
+
+import { BN } from '@c4tplatform/caminojs'
+import { ONEAVAX } from '@c4tplatform/caminojs/dist/utils'
+import Big from 'big.js'
+import { Component, Prop, Vue } from 'vue-property-decorator'
+
+import { ava } from '@/AVA'
+import AvaxInput from '@/components/misc/AvaxInput.vue'
+import { WalletHelper } from '@/helpers/wallet_helper'
+import AvaAsset from '@/js/AvaAsset'
+import { MultisigWallet } from '@/js/wallets/MultisigWallet'
+import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
+
+import Modal from '../../modals/Modal.vue'
+import CamBtn from '@/components/CamBtn.vue'
+import Alert from '@/components/Alert.vue'
+
+@Component({
+    components: {
+        AvaxInput,
+        Modal,
+        CamBtn,
+        Alert,
+    },
+})
+export default class ModalUndeposit extends Vue {
+    @Prop({ required: true }) depositTxID!: string
+    @Prop() pendingUndepositTx!: any
+    @Prop({ required: true }) maxUndepositable!: BN
+    @Prop({ required: true }) amount!: BN
+    @Prop() canExecuteMultisigTx!: boolean
+
+    undeposit: number = 0
+    amt: BN = new BN(0)
+    // @ts-ignore
+    helpers = this.globalHelper()
+
+    $refs!: {
+        modal: Modal
+    }
+
+    get submitSentence(): string {
+        if (this.canExecuteMultisigTx) return 'Confirm Execute transaction'
+        else return 'Undeposit'
+    }
+
+    open() {
+        if (this.pendingUndepositTx) {
+            this.amt = this.pendingUndepositTx.amountToUndeposit
+        }
+        this.$refs.modal.open()
+    }
+
+    close() {
+        this.$refs.modal.close()
+    }
+
+    beforeClose() {
+        this.undeposit = 0
+    }
+
+    updateBalance(): void {
+        this.$store.dispatch('updateBalances')
+    }
+
+    formattedAmount(val: BN): string {
+        let big = Big(val.toString()).div(Big(ONEAVAX.toString()))
+        return big.toLocaleString()
+    }
+
+    get activeWallet(): MultisigWallet {
+        return this.$store.state.activeWallet
+    }
+
+    get isMultiSig(): boolean {
+        return this.activeWallet.type === 'multisig'
+    }
+
+    get feeAmt(): string {
+        return this.formattedAmount(ava.PChain().getTxFee())
+    }
+
+    get ava_asset(): AvaAsset | null {
+        return this.$store.getters['Assets/AssetAVA']
+    }
+
+    get nativeAssetSymbol(): string {
+        return this.ava_asset?.symbol ?? ''
+    }
+
+    get pendingSendMultisigTX(): SignavaultTx | undefined {
+        return this.$store.getters['Signavault/transactions'].find(
+            (item: any) =>
+                item?.tx?.alias === this.activeWallet.getAllAddressesP()[0] &&
+                WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx) === 'UnlockDepositTx'
+        )
+    }
+
+    async updateRewards() {
+        await this.$store.dispatch('Assets/updateUTXOs')
+        await this.$store.dispatch('History/updateTransactionHistory')
+        await this.$store.dispatch('Platform/updateAllDepositOffers')
+        await this.$store.dispatch('Platform/updateRewards')
+    }
+
+    async confirmClaim() {
+        // @ts-ignore
+        let { dispatchNotification } = this.globalHelper()
+        if (this.isMultiSig && this.canExecuteMultisigTx) {
+            this.$emit('confirmClaim')
+            return
+        }
+        try {
+            await WalletHelper.buildUnlockDepositTx(
+                this.$store.state.activeWallet,
+                this.amt,
+                this.depositTxID
+            )
+                .then(async (value) => {
+                    this.updateBalance()
+                    this.updateRewards()
+                    if (this.isMultiSig) {
+                        this.$store.dispatch('Signavault/updateTransaction').then(() => {
+                            this.$emit('updateButtonStatus')
+                        })
+                        this.undeposit = 1
+                    } else {
+                        this.helpers.dispatchNotification({
+                            message: `Undeposit Successful for ${this.formattedAmount(this.amt)} ${
+                                this.nativeAssetSymbol
+                            }`,
+                            type: 'success',
+                        })
+                        this.undeposit = 0
+                    }
+                })
+                .catch((err) => {
+                    dispatchNotification({
+                        message: this.$t('notifications.something_went_wrong'),
+                        type: 'error',
+                    })
+                    console.log(err)
+                })
+        } catch (e) {
+            console.log(e)
+        }
+    }
+}
+</script>
+<style scoped lang="scss">
+@use '../../../styles/abstracts/mixins';
+.w {
+    .col1 {
+        grid-template-columns: 1fr !important;
+        > * {
+            grid-template-columns: 1fr !important;
+        }
+
+        * {
+            grid-template-columns: 1fr !important;
+        }
+    }
+}
+.claim-reward-modal {
+    padding: 30px 22px;
+    text-align: center;
+    width: 600px;
+    overflow-x: hidden;
+}
+
+.modal-buttons {
+    display: flex;
+    justify-content: end;
+    margin-top: 20px;
+    gap: 10px;
+}
+
+.text--modal {
+    @include mixins.typography-body-2;
+    text-align: start;
+}
+
+@media screen and (max-width: 720px) {
+    .claim-reward-modal {
+        width: 350px;
+    }
+}
+@media screen and (min-width: 720px) and (max-width: 1440px) {
+    .claim-reward-modal {
+        width: 475px;
+    }
+}
+</style>

--- a/src/components/wallet/earn/ModalUndeposit.vue
+++ b/src/components/wallet/earn/ModalUndeposit.vue
@@ -10,7 +10,13 @@
                     }}
                 </p>
                 <br />
-                <div v-if="isMultiSig && canExecuteMultisigTx">
+                <div
+                    v-if="
+                        isMultiSig &&
+                        canExecuteMultisigTx &&
+                        pendingUndepositTx.hasSufficientUnlocked
+                    "
+                >
                     <AvaxInput
                         v-model="amount"
                         :initial="amount"

--- a/src/components/wallet/earn/UndepositButtons.vue
+++ b/src/components/wallet/earn/UndepositButtons.vue
@@ -231,7 +231,7 @@ export default class UndepositButtons extends Vue {
             this.updateButtonStatus()
         } catch (e: any) {
             this.helpers.dispatchNotification({
-                message: 'Your signature is not saved.',
+                message: 'Your signature has not been saved.',
                 type: 'error',
             })
         }

--- a/src/components/wallet/earn/UndepositButtons.vue
+++ b/src/components/wallet/earn/UndepositButtons.vue
@@ -224,7 +224,7 @@ export default class UndepositButtons extends Vue {
         try {
             await wallet.addSignatures(this.pendingTX?.tx)
             this.helpers.dispatchNotification({
-                message: 'Your signature saved successfully!',
+                message: 'Your signature has been saved successfully!',
                 type: 'success',
             })
             this.$store.dispatch('Signavault/updateTransaction')

--- a/src/components/wallet/earn/UndepositButtons.vue
+++ b/src/components/wallet/earn/UndepositButtons.vue
@@ -1,0 +1,312 @@
+<template>
+    <div>
+        <template v-if="buttonStatus === ButtonStatus.DEFAULT">
+            <CamBtn
+                variant="primary"
+                @click="openUndepositModal"
+                :disabled="isUndepositDisabled || signavaultPendingTx"
+            >
+                {{ $t('earn.rewards.active_earning.undeposit') }}
+            </CamBtn>
+        </template>
+        <template v-else-if="buttonStatus === ButtonStatus.PENDING_TRANSACTION">
+            <div class="button__group">
+                <CamBtn variant="negative" @click="openAbortModal">
+                    {{ $t('earn.rewards.active_earning.abort') }}
+                </CamBtn>
+                <div v-if="canExecuteMultisigTx">
+                    <CamBtn
+                        variant="primary"
+                        @click="openUndepositModal"
+                        :disabled="!canExecuteMultisigTx"
+                    >
+                        {{ $t('transfer.multisig.execute_transaction') }}
+                    </CamBtn>
+                </div>
+                <div v-else>
+                    <CamBtn variant="transparent" @click="signMultisigTx" :disabled="signStatus">
+                        {{
+                            $t('earn.rewards.active_earning.signed', {
+                                nbSigners: sigValue,
+                                threshold: threshold,
+                            })
+                        }}
+                    </CamBtn>
+                </div>
+            </div>
+        </template>
+        <template v-else-if="buttonStatus === ButtonStatus.MULTISIG_WALLET">
+            <CamBtn
+                v-if="!initMultisig"
+                variant="primary"
+                @click="initMultisigTx"
+                :disabled="isUndepositDisabled || signavaultPendingTx"
+            >
+                {{ $t('earn.rewards.active_earning.undeposit') }}
+            </CamBtn>
+            <div v-else class="button__group">
+                <CamBtn variant="transparent" @click="cancelInitMultisigTx">Cancel</CamBtn>
+                <CamBtn
+                    variant="primary"
+                    @click="openUndepositModal"
+                    :disabled="isUndepositDisabled || signavaultPendingTx"
+                >
+                    {{ $t('earn.rewards.active_earning.initiate_transaction') }}
+                </CamBtn>
+            </div>
+        </template>
+        <ModalUndeposit
+            :maxUndepositable="unlockableAmount"
+            ref="modal_undeposit"
+            :depositTxID="reward.deposit.depositTxID"
+            @confirmClaim="issueMultisigTx"
+            @updateButtonStatus="updateButtonStatus"
+            @close="updateButtonStatus"
+            :pendingUndepositTx="pendingUndepositTx"
+            :amount="pendingUndepositTx?.amountToUndeposit"
+            :canExecuteMultisigTx="canExecuteMultisigTx"
+        />
+        <ModalAbortSigning
+            ref="abort"
+            title="Abort undeposit transaction"
+            :modalText="$t('earn.rewards.abort_modal.message')"
+            @cancelTx="cancelMultisigTx"
+        />
+    </div>
+</template>
+<script lang="ts">
+import { Component, Vue, Prop, Watch } from 'vue-property-decorator'
+import { PlatformRewardDeposit } from '@/store/modules/platform/types'
+import ModalUndeposit from './ModalUndeposit.vue'
+import ModalAbortSigning from './ModalAbortSigning.vue'
+import CamBtn from '@/components/CamBtn.vue'
+import { BN } from '@c4tplatform/caminojs/dist'
+import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
+import { MultisigWallet } from '@/js/wallets/MultisigWallet'
+import Alert from '@/components/Alert.vue'
+import { UndepositPendingTx } from '@/helpers/helper'
+
+enum ButtonStatus {
+    DEFAULT = 0,
+    PENDING_TRANSACTION = 1,
+    MULTISIG_WALLET = 2,
+}
+
+@Component({
+    components: {
+        ModalUndeposit,
+        CamBtn,
+        ModalAbortSigning,
+        Alert,
+    },
+})
+export default class UndepositButtons extends Vue {
+    @Prop() pendingUndepositTx!: UndepositPendingTx
+    @Prop() reward!: PlatformRewardDeposit
+
+    // @ts-ignore
+    helpers = this.globalHelper()
+
+    ButtonStatus = ButtonStatus
+    buttonStatus: ButtonStatus = ButtonStatus.DEFAULT
+    initMultisig: boolean = false
+
+    $refs!: {
+        abort: ModalAbortSigning
+        modal_undeposit: ModalUndeposit
+    }
+
+    @Watch('pendingTX')
+    watchPendingTX() {
+        this.updateButtonStatus()
+    }
+
+    mounted() {
+        this.updateButtonStatus()
+    }
+
+    initMultisigTx() {
+        this.$emit('updateDisclaimer')
+        this.initMultisig = true
+    }
+
+    cancelInitMultisigTx() {
+        this.$emit('updateDisclaimer')
+        this.initMultisig = false
+    }
+
+    get pendingTX(): SignavaultTx | undefined {
+        let pendingUndepositTx = this.pendingUndepositTx?.pendingTx as SignavaultTx
+        return pendingUndepositTx
+    }
+
+    get unlockableAmount(): BN {
+        return this.reward.deposit.unlockableAmount
+    }
+
+    get isUndepositDisabled() {
+        return this.reward.deposit.unlockableAmount.isZero()
+    }
+
+    get activeWallet() {
+        return this.$store.state.activeWallet
+    }
+
+    get sigValue() {
+        return this.pendingTX?.tx.owners?.filter((owner) => !!owner.signature)?.length
+    }
+
+    get threshold() {
+        return this.pendingTX?.tx.threshold
+    }
+
+    get signStatus(): boolean {
+        let isSigned = false
+        this.txOwners.forEach((owner) => {
+            if (
+                this.activeWallet.wallets.find((w) => w?.getAllAddressesP()?.[0] === owner.address)
+            ) {
+                if (owner.signature) isSigned = true
+            }
+        })
+        return isSigned
+    }
+
+    get canExecuteMultisigTx(): boolean {
+        let signers = 0
+        let threshold = this.pendingTX?.tx?.threshold
+        this.txOwners.forEach((owner) => {
+            if (owner.signature) signers++
+        })
+        if (threshold) return signers >= threshold
+        return false
+    }
+
+    get disableSignButton(): boolean {
+        let isSigned = false
+        this.txOwners.forEach((owner) => {
+            if (
+                this.activeWallet.wallets.find((w) => w?.getAllAddressesP()?.[0] === owner.address)
+            ) {
+                if (owner.signature) isSigned = true
+            }
+        })
+        return isSigned
+    }
+
+    get signavaultPendingTx() {
+        return this.$store.getters['Signavault/transactions'].length > 0
+    }
+
+    get txOwners() {
+        return this.pendingTX?.tx?.owners ?? []
+    }
+
+    updateButtonStatus() {
+        if (
+            this.pendingUndepositTx?.depositTxIDs?.find(
+                (tx: string) => tx === this.reward.deposit.depositTxID
+            )
+        ) {
+            this.buttonStatus = ButtonStatus.PENDING_TRANSACTION
+        } else if (this.activeWallet.type === 'multisig' && !this.pendingTX) {
+            this.buttonStatus = ButtonStatus.MULTISIG_WALLET
+        } else {
+            this.buttonStatus = ButtonStatus.DEFAULT
+        }
+    }
+
+    async signMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.debug('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingTX) return console.debug('MultiSigTx::sign: Invalid Tx')
+        try {
+            await wallet.addSignatures(this.pendingTX?.tx)
+            this.helpers.dispatchNotification({
+                message: 'Your signature saved successfully!',
+                type: 'success',
+            })
+            this.$store.dispatch('Signavault/updateTransaction')
+            this.updateButtonStatus()
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: 'Your signature is not saved.',
+                type: 'error',
+            })
+        }
+    }
+    async issueMultisigTx() {
+        const wallet = this.activeWallet
+        if (!wallet || !(wallet instanceof MultisigWallet))
+            return console.log('MultiSigTx::sign: Invalid wallet')
+        if (!this.pendingTX) return console.log('MultiSigTx::sign: Invalid Tx')
+        try {
+            let txID = await wallet.issueExternal(this.pendingTX?.tx)
+            let { dispatchNotification } = this.helpers
+            await this.$store.dispatch('Assets/updateUTXOs')
+            await this.$store.dispatch('Platform/update')
+            dispatchNotification({
+                message: `Deposit Successful (TX: ${txID})`,
+                type: 'success',
+            })
+            await this.$store.dispatch('Signavault/updateTransaction')
+            this.updateButtonStatus()
+            this.closeUndepositModal()
+        } catch (e: any) {
+            this.helpers.dispatchNotification({
+                message: this.$t('notifications.execute_multisig_transaction_error'),
+                type: 'error',
+            })
+        }
+    }
+    async cancelMultisigTx() {
+        try {
+            const wallet = this.activeWallet as MultisigWallet
+            if (this.pendingTX) {
+                await wallet.cancelExternal(this.pendingTX?.tx)
+                this.helpers.dispatchNotification({
+                    message: this.$t('transfer.multisig.transaction_aborted'),
+                    type: 'success',
+                })
+                await this.$store.dispatch('Assets/updateUTXOs')
+                await this.$store.dispatch('Signavault/updateTransaction')
+                this.updateButtonStatus()
+            }
+        } catch (err) {
+            console.error('Error canceling multisig transaction:', err)
+            this.helpers.dispatchNotification({
+                message: this.$t('transfer.multisig.cancel_transaction_failed'),
+                type: 'error',
+            })
+        }
+    }
+
+    openUndepositModal() {
+        this.$refs.modal_undeposit.open()
+    }
+
+    closeUndepositModal() {
+        if (this.initMultisig) {
+            this.initMultisig = false
+            this.$emit('updateDisclaimer')
+        }
+        this.$refs.modal_undeposit.close()
+    }
+
+    openAbortModal() {
+        this.$refs.abort.open()
+    }
+}
+</script>
+
+<style scoped lang="scss">
+@use '../../../styles/abstracts/mixins';
+
+.button__group {
+    display: flex;
+    margin-left: auto;
+    gap: 0.4rem;
+    justify-content: end;
+}
+</style>

--- a/src/components/wallet/earn/UserRewards.vue
+++ b/src/components/wallet/earn/UserRewards.vue
@@ -101,6 +101,9 @@ export default class UserRewards extends Vue {
         let totalConsumedLocked = new BN(0)
         let totalProducedLocked = new BN(0)
 
+        // Track total unlocked amount
+        let totalUnlockedAmount = new BN(0)
+
         // Extract deposit transaction IDs
         const depositTxIDs: string[] = []
 
@@ -130,17 +133,25 @@ export default class UserRewards extends Vue {
             }
         }
 
-        // Process outputs to find produced locked amounts
+        // Process outputs to find produced locked amounts and unlocked outputs
         const outs = tx.getOuts()
         for (let i = 0; i < outs.length; i++) {
             const output = outs[i]
             const outputObj = output.getOutput()
 
             if (outputObj && outputObj._typeName === 'LockedOut') {
+                // Handle locked outputs
                 const producedLocked = outputObj.getOutput().amount
                 if (Buffer.isBuffer(producedLocked)) {
                     const bnAmount = bintools.fromBufferToBN(producedLocked)
                     totalProducedLocked = totalProducedLocked.add(bnAmount)
+                }
+            } else if (outputObj && 'amount' in outputObj) {
+                // Handle unlocked outputs
+                const amountBuffer = outputObj.amount
+                if (Buffer.isBuffer(amountBuffer)) {
+                    const amount = bintools.fromBufferToBN(amountBuffer)
+                    totalUnlockedAmount = totalUnlockedAmount.add(amount)
                 }
             }
         }
@@ -148,10 +159,18 @@ export default class UserRewards extends Vue {
         // Calculate amount to undeposit (consumedLocked - producedLocked)
         const amountToUndeposit = totalConsumedLocked.sub(totalProducedLocked)
 
+        // Get transaction fee
+        const txFee = ava.PChain().getTxFee()
+
+        // This ensures total unlocked amount is at least (amountToUndeposit - txFee)
+        const minimumExpectedUnlocked = amountToUndeposit.sub(txFee)
+        const hasSufficientUnlocked = totalUnlockedAmount.gte(minimumExpectedUnlocked)
+
         return {
             amountToUndeposit: amountToUndeposit,
             depositTxIDs,
             pendingTx,
+            hasSufficientUnlocked,
         }
     }
 

--- a/src/components/wallet/earn/UserRewards.vue
+++ b/src/components/wallet/earn/UserRewards.vue
@@ -14,6 +14,7 @@
                 :reward="reward"
                 class="reward_card"
                 @updatePendingDepositClaim="updatePendingDepositClaim"
+                :pendingUndepositTx="pendingUndepositTx"
             />
         </div>
     </div>
@@ -26,6 +27,13 @@ import { Component, Vue } from 'vue-property-decorator'
 import DepositRewardCard from '@/components/wallet/earn/DepositRewardCard.vue'
 import { PlatformRewards } from '@/store/modules/platform/types'
 import TreasuryRewardCard from './TreasuryRewardCard.vue'
+import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
+import { WalletHelper } from '@/helpers/wallet_helper'
+import { UnlockDepositTx, UnsignedTx } from '@c4tplatform/caminojs/dist/apis/platformvm'
+import { BN, Buffer } from '@c4tplatform/caminojs/dist'
+import { ava, bintools } from '@/AVA'
+import { WalletType } from '@/js/wallets/types'
+import { bnToBig, UndepositPendingTx } from '@/helpers/helper'
 
 @Component({
     components: {
@@ -68,6 +76,83 @@ export default class UserRewards extends Vue {
 
     get firstTreasuryReward() {
         return this.platformRewards.treasuryRewards[0] ?? null
+    }
+
+    get activeWallet(): WalletType {
+        return this.$store.state.activeWallet
+    }
+
+    get pendingUndepositTx(): UndepositPendingTx | null {
+        const pendingTx = this.$store.getters['Signavault/transactions'].find(
+            (item: SignavaultTx) =>
+                item?.tx?.alias === this.activeWallet.getStaticAddress('P') &&
+                WalletHelper.getUnsignedTxType(item?.tx?.unsignedTx) === 'UnlockDepositTx'
+        )
+        if (!pendingTx?.tx?.unsignedTx) {
+            return null
+        }
+
+        const unsignedTx = new UnsignedTx()
+        unsignedTx.fromBuffer(Buffer.from(pendingTx.tx.unsignedTx, 'hex'))
+
+        const tx = unsignedTx.getTransaction() as UnlockDepositTx
+
+        // Track total consumed and produced locked amounts
+        let totalConsumedLocked = new BN(0)
+        let totalProducedLocked = new BN(0)
+
+        // Extract deposit transaction IDs
+        const depositTxIDs: string[] = []
+
+        // Process inputs to find consumed locked amounts and deposit txIDs
+        const ins = tx.getIns()
+        for (let i = 0; i < ins.length; i++) {
+            const input = ins[i]
+            const baseInput = input.getInput()
+
+            if (baseInput && baseInput._typeName === 'LockedIn') {
+                // Get consumed locked amount
+                const consumedLocked = baseInput.getInput().amount
+                if (Buffer.isBuffer(consumedLocked)) {
+                    const bnAmount = bintools.fromBufferToBN(consumedLocked)
+                    totalConsumedLocked = totalConsumedLocked.add(bnAmount)
+                }
+
+                // Extract deposit txID
+                const lockedIn = baseInput as any
+                if (lockedIn.ids && lockedIn.ids.depositTxID && lockedIn.ids.depositTxID.txid) {
+                    const depositTxIDBuffer = lockedIn.ids.depositTxID.txid
+                    const depositTxID = bintools.cb58Encode(depositTxIDBuffer)
+                    if (!depositTxIDs.includes(depositTxID)) {
+                        depositTxIDs.push(depositTxID)
+                    }
+                }
+            }
+        }
+
+        // Process outputs to find produced locked amounts
+        const outs = tx.getOuts()
+        for (let i = 0; i < outs.length; i++) {
+            const output = outs[i]
+            const outputObj = output.getOutput()
+
+            if (outputObj && outputObj._typeName === 'LockedOut') {
+                const producedLocked = outputObj.getOutput().amount
+                if (Buffer.isBuffer(producedLocked)) {
+                    const bnAmount = bintools.fromBufferToBN(producedLocked)
+                    totalProducedLocked = totalProducedLocked.add(bnAmount)
+                }
+            }
+        }
+
+        // Calculate amount to undeposit (consumedLocked - producedLocked)
+        const amountToUndeposit = totalConsumedLocked.sub(totalProducedLocked)
+
+        return {
+            amountToUndeposit: amountToUndeposit,
+            depositTxIDs,
+            pendingTx,
+        }
     }
 
     get nativeAssetSymbol(): string {

--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -9,9 +9,16 @@ import {
 
 import { ONEAVAX, PayloadBase, PayloadTypes } from '@c4tplatform/caminojs/dist/utils'
 import Big from 'big.js'
+import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
 
 import { Buffer, BN } from '@c4tplatform/caminojs/dist'
 import createHash from 'create-hash'
+
+export interface UndepositPendingTx {
+    amountToUndeposit: BN
+    depositTxIDs: string[]
+    pendingTx: SignavaultTx
+}
 
 function bnToBig(val: BN, denomination = 0): Big {
     return new Big(val.toString()).div(Math.pow(10, denomination))

--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -15,6 +15,7 @@ import { Buffer, BN } from '@c4tplatform/caminojs/dist'
 import createHash from 'create-hash'
 
 export interface UndepositPendingTx {
+    hasSufficientUnlocked: boolean
     amountToUndeposit: BN
     depositTxIDs: string[]
     pendingTx: SignavaultTx

--- a/src/helpers/wallet_helper.ts
+++ b/src/helpers/wallet_helper.ts
@@ -647,6 +647,35 @@ class WalletHelper {
         return await ava.PChain().issueTx(tx)
     }
 
+    static async buildUnlockDepositTx(wallet: WalletType, amount: BN, depositTxID: string) {
+        const pAddressStrings = wallet.getAllAddressesP()
+        const signerAddresses = wallet.getSignerAddresses('P')
+        const unsignedTx = await ava
+            .PChain()
+            .buildUnlockDepositTx(
+                wallet.platformUtxoset,
+                [pAddressStrings, signerAddresses],
+                Buffer.alloc(0),
+                [
+                    {
+                        amount: amount.toNumber(),
+                        depositTxID,
+                    },
+                ]
+            )
+
+        try {
+            const tx = await wallet.signP(unsignedTx)
+            return await ava.PChain().issueTx(tx)
+        } catch (err) {
+            if (err instanceof SignatureError) {
+                return undefined
+            } else {
+                throw err
+            }
+        }
+    }
+
     static async buildAddDepositOfferTx(wallet: WalletType, offer: DepositOffer) {
         const pAddressStrings = wallet.getAllAddressesP()
         const signerAddresses = wallet.getSignerAddresses('P')

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -589,7 +589,8 @@
                 "undeposit": "Undeposit",
                 "initiated_undeposit": "Initiated Undeposit Amount",
                 "unlock_amount": "How much {nativeAssetSymbol} you would like to unlock?",
-                "total_to_unlock": "Total un-depositable {nativeAssetSymbol} availble"
+                "total_to_unlock": "Total un-depositable {nativeAssetSymbol} availble",
+                "total_to_unlock_check": "Total unlocked amount is less than expected"
             },
             "pending_rewards": {
                 "title": "Expired deposit rewards",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -583,7 +583,13 @@
                 "deposit_start": "Deposit Start",
                 "deposit_end": "Deposit End",
                 "deposit_amount": "Deposit Amount",
-                "deposited_amount": "Deposited Amount"
+                "deposited_amount": "Deposited Amount",
+                "undepositable_amount": "Undepositable Amount",
+                "already_undeposited": "Already Undeposited",
+                "undeposit": "Undeposit",
+                "initiated_undeposit": "Initiated Undeposit Amount",
+                "unlock_amount": "How much {nativeAssetSymbol} you would like to unlock?",
+                "total_to_unlock": "Total un-depositable {nativeAssetSymbol} availble"
             },
             "pending_rewards": {
                 "title": "Expired deposit rewards",
@@ -594,6 +600,13 @@
                 "are_you_sure": "Are you sure you want to claim {amount} {symbol} rewards?",
                 "note_message": "Transaction fee:  {fee} {symbol}.",
                 "confirmation_message": "{amount} {symbol} has been claimed.",
+                "signature_collected": "Your signature has been collected.",
+                "confirm": "Confirm",
+                "cancel": "Cancel",
+                "alert_info_message": "The requested claim operation will claim less funds than the transaction will cost. Please confirm that you want to proceed with this operation."
+            },
+            "undeposit_modal": {
+                "confirmation_message": "{amount} {symbol} has been undeposited.",
                 "signature_collected": "Your signature has been collected.",
                 "confirm": "Confirm",
                 "cancel": "Cancel",


### PR DESCRIPTION
# Implement Deposit Unlocking Functionality

## Description
This PR implements the complete process for unlocking deposits using UnlockDepositTx. Users can now initiate the unlocking of deposits from both single-signature and multisignature wallets, with full support for tracking pending transactions and executing them when signature thresholds are met.

## Changes
- Implemented transaction building logic for unlocking deposits
- Added specialized handling for multisignature wallets:
  - Signature collection interface
  - Threshold tracking
  - Transaction status
- Implemented extraction of deposit details from LockedIn inputs
- Added execution flow to submit transactions when signature threshold is reached
- Added UI elements to view deposit unlock status and progress