### PR TITLE
fix(network): fix vuex handling data mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,5 @@ By default, there is one network option to connect to: `Columbus`.
 
 -   Camino API: `https://columbus.camino.network`
 -   Explorer API: `tbd`
+
+

--- a/src/js/AvaNetwork.ts
+++ b/src/js/AvaNetwork.ts
@@ -74,12 +74,12 @@ class AvaNetwork {
                     method: 'info.getNetworkID',
                 },
                 {
-                    withCredentials: true,
+                    withCredentials: false,
                 }
             )
-            this.withCredentials = true
-        } catch (e) {
             this.withCredentials = false
+        } catch (e) {
+            this.withCredentials = true
         }
     }
 

--- a/src/store/modules/network/network.ts
+++ b/src/store/modules/network/network.ts
@@ -24,7 +24,20 @@ const network_module: Module<NetworkState, RootState> = {
             state.networks.push(net)
         },
         selectNetwork(state, net: AvaNetwork) {
-            state.selectedNetwork = net
+            const networkCopy = {
+                name: net.name,
+                url: net.url,
+                networkId: net.networkId,
+                explorerUrl: net.explorerUrl,
+                explorerSiteUrl: net.explorerSiteUrl,
+                signavaultUrl: net.signavaultUrl,
+                readonly: net.readonly,
+                ip: net.ip,
+                port: net.port,
+                protocol: net.protocol,
+                withCredentials: net.withCredentials,
+            } as AvaNetwork
+            state.selectedNetwork = networkCopy
         },
     },
     getters: {


### PR DESCRIPTION
## Problem
When switching networks while logged in, the application throws a TypeError: `t.apply is not a function` originating from the `state.selectedNetwork = net` line in the network module's selectNetwork mutation. This error only occurs for authenticated users.

## Root Cause
The AvaNetwork class instance contains methods and possibly circular references that Vue's reactivity system cannot properly handle, causing runtime errors when the object is directly assigned to state.