### PR TITLE
chore: update caminojs and fix cypress tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -133,7 +133,7 @@ jobs:
         env:
           USE_HTTP: true
         with:
-          wait-on: 'http://localhost:5001/, http://localhost:5002/, http://localhost:5003/'
+          wait-on: 'http://localhost:5002/, http://localhost:5003/ , http://localhost:5001/'
           working-directory: camino-suite
           # wait for 3 minutes for the server to respond
           wait-on-timeout: 180

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "@babel/plugin-transform-runtime": "^7.15.8",
         "@babel/preset-env": "^7.15.8",
         "@babel/preset-typescript": "^7.18.6",
-        "@c4tplatform/caminojs": "^1.3.1",
+        "@c4tplatform/caminojs": "^1.4.0",
         "@c4tplatform/vue_components": "^0.2.6",
         "@cypress/grep": "^3.1.4",
         "@cypress/webpack-preprocessor": "^5.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,10 +1066,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@c4tplatform/caminojs@^1.2.0-rc1":
-  version "1.2.0-rc1"
-  resolved "https://registry.yarnpkg.com/@c4tplatform/caminojs/-/caminojs-1.2.0-rc1.tgz#24f41054cdc7972944b714d7de0f21e078bb3f7e"
-  integrity sha512-wQDFr4vvnjwFGR8xVBQoYe2W+RbEt8bm7eE4h7cxftycDCKqb9t4kf8ewfH58aNhrAvmK8ZgXmIt6y5UJPDpKQ==
+"@c4tplatform/caminojs@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@c4tplatform/caminojs/-/caminojs-1.4.0.tgz#436939507949fcd0ef3189b3275a4eb71b1e2e26"
+  integrity sha512-4jl2LPV3uG/VXK2s0r3hiLGPqSaqaDQ90Ks2XFVXJrMxp91NPLqaHv2VTZucL48eNcP38tT7soLV65FWHGSc+g==
   dependencies:
     assert "2.0.0"
     axios "^0.26.1"


### PR DESCRIPTION
This PR includes the following changes:
- Updated caminojs to the latest version (1.4.0) to include recently added features and improvements.
- Fixed Cypress the Explorer app.
