### PR TITLE
fix: add contract validation for cross-network support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,11 @@ export enum KYC_VARIANT {
     KYC_BASIC = 'kyc_basic',
     KYB_BASIC = 'kyb_basic',
 }
+
+// Constants for ERC interface IDs
+export const ERC721_INTERFACE_ID = '0x80ac58cd'
+export const ERC1155_INTERFACE_ID = '0xd9b67a26'
+
 export const MINUTE_MS = 60000
 export const HOUR_MS = MINUTE_MS * 60
 export const DAY_MS = HOUR_MS * 24

--- a/src/js/ERCNftToken.ts
+++ b/src/js/ERCNftToken.ts
@@ -4,7 +4,7 @@ import { AbiItem, Contract, web3 } from '@/evm'
 import IERC721Abi from '@/abi/IERC721MetaData.json'
 import IERC1155Abi from '@/abi/IERC1155MetaData.json'
 import { ERCNftBalance, ERCNftTokenInput } from '@/store/modules/assets/modules/types'
-import { CF_IPFS_BASE } from '@/constants'
+import { CF_IPFS_BASE, ERC1155_INTERFACE_ID, ERC721_INTERFACE_ID } from '@/constants'
 
 interface TokenDataCache {
     [index: number]: string
@@ -139,55 +139,88 @@ class ERCNftToken {
     }
 
     async getAllTokensIds(address: string): Promise<ERCNftBalance[]> {
-        if (!this.canSupport || this.data.ercTokenIds.length == 0) return []
+        // Early exit if not supported or no token IDs
+        if (!this.canSupport || this.data.ercTokenIds.length === 0) return []
+
         let res: ERCNftBalance[] = []
 
-        if (this.contract)
+        if (this.contract) {
             try {
-                if (this.data.type === 'ERC1155') {
-                    const balances = await this.contract.methods
-                        .balanceOfBatch(
-                            Array(this.data.ercTokenIds.length).fill(address),
-                            this.data.ercTokenIds
-                        )
-                        .call()
-                    balances.forEach((s: string, i: number) => {
-                        res.push({
-                            tokenId: this.data.ercTokenIds[i],
-                            quantity: parseInt(s),
-                        })
-                    })
-                } else {
-                    for (const token of this.data.ercTokenIds) {
-                        try {
+                // First check if the contract is deployed on this network
+                try {
+                    // Check if the contract supports the correct interface for its type
+                    const interfaceId =
+                        this.data.type === 'ERC1155' ? ERC1155_INTERFACE_ID : ERC721_INTERFACE_ID
+                    await this.contract.methods.supportsInterface(interfaceId).call()
+
+                    if (this.data.type === 'ERC1155') {
+                        const balances = await this.contract.methods
+                            .balanceOfBatch(
+                                Array(this.data.ercTokenIds.length).fill(address),
+                                this.data.ercTokenIds
+                            )
+                            .call()
+
+                        balances.forEach((s: string, i: number) => {
                             res.push({
-                                tokenId: token,
-                                quantity:
-                                    (
-                                        await this.contract?.methods.ownerOf(token).call()
-                                    ).toLowerCase() === address
-                                        ? 1
-                                        : 0,
+                                tokenId: this.data.ercTokenIds[i],
+                                quantity: parseInt(s),
                             })
-                        } catch (err: any) {
-                            if (
-                                err.message.includes(
-                                    'Returned error: execution reverted: ERC721: invalid token ID'
-                                )
-                            ) {
+                        })
+                    } else {
+                        for (const token of this.data.ercTokenIds) {
+                            try {
+                                const owner = await this.contract?.methods.ownerOf(token).call()
                                 res.push({
                                     tokenId: token,
-                                    quantity: 0,
+                                    quantity: owner.toLowerCase() === address.toLowerCase() ? 1 : 0,
                                 })
-                            } else {
-                                console.error(err)
+                            } catch (err: any) {
+                                if (
+                                    err.message.includes(
+                                        'Returned error: execution reverted: ERC721: invalid token ID'
+                                    )
+                                ) {
+                                    res.push({
+                                        tokenId: token,
+                                        quantity: 0,
+                                    })
+                                } else {
+                                    console.error('Error checking token ownership:', err)
+                                    res.push({
+                                        tokenId: token,
+                                        quantity: 0,
+                                    })
+                                }
                             }
                         }
                     }
+                } catch (interfaceErr) {
+                    console.warn(
+                        `Contract does not exist or is not a valid ${this.data.type} on the current network`
+                    )
+                    // Return empty balances for all tokenIds
+                    return this.data.ercTokenIds.map((tokenId) => ({
+                        tokenId,
+                        quantity: 0,
+                    }))
                 }
             } catch (e) {
-                console.error(e)
+                console.error('Error in getAllTokensIds:', e)
+                // Return empty balances as fallback
+                return this.data.ercTokenIds.map((tokenId) => ({
+                    tokenId,
+                    quantity: 0,
+                }))
             }
+        } else {
+            // If no contract instance, return all tokens with zero balance
+            return this.data.ercTokenIds.map((tokenId) => ({
+                tokenId,
+                quantity: 0,
+            }))
+        }
+
         return res
     }
 


### PR DESCRIPTION
## Contract Validation for Cross-Network Support

### Problem
When switching networks, the `getAllTokensIds` function was failing with "Out of Gas" errors because it was attempting to interact with contracts that don't exist on the target network.