### PR TITLE
fix(wallet): update rewards correctly on active wallet change

### DIFF
--- a/src/components/SidePanels/TxHistoryRow.vue
+++ b/src/components/SidePanels/TxHistoryRow.vue
@@ -47,12 +47,16 @@ export default class TxHistoryRow extends Vue {
         let chains = this.$store.state.History.chains
         if (network.explorerUrl && chains.length > 0) {
             let alias = chains?.find(
-                (elem: Chain) => elem.chainID === this.transaction.chainID
-            ).chainAlias
-            let url = `/explorer/${network.name.toLowerCase()}/${alias}-chain/tx/${
-                this.transaction.id
-            }`
-            return url
+                (elem: Chain) =>
+                    this.transaction?.chainID && elem.chainID === this.transaction?.chainID
+            )
+            if (alias && alias.chainAlias) {
+                let url = `/explorer/${network.name.toLowerCase()}/${alias.chainAlias}-chain/tx/${
+                    this.transaction.id
+                }`
+                return url
+            }
+            return ''
         } else return ''
     }
 

--- a/src/components/wallet/earn/UserRewards.vue
+++ b/src/components/wallet/earn/UserRewards.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator'
+import { Component, Vue, Watch } from 'vue-property-decorator'
 
 import DepositRewardCard from '@/components/wallet/earn/DepositRewardCard.vue'
 import { PlatformRewards } from '@/store/modules/platform/types'
@@ -70,6 +70,19 @@ export default class UserRewards extends Vue {
         return this.platformRewards.depositRewards.length > 0
     }
 
+    @Watch('activeWallet')
+    onActiveWalletChange() {
+        console.log('Active wallet changed, updating rewards...')
+        this.$store.dispatch('Assets/updateUTXOs').then(() => {
+            this.$store.dispatch('Platform/updateAllDepositOffers').then(async () => {
+                await Promise.all([
+                    this.$store.dispatch('Platform/updateRewards'),
+                    this.$store.dispatch('Signavault/updateTransaction'),
+                    this.updateExpiredDepositRewards(),
+                ])
+            })
+        })
+    }
     get hasPendingRewards(): boolean {
         return this.platformRewards.treasuryRewards.length > 0
     }

--- a/src/store/modules/history/history.ts
+++ b/src/store/modules/history/history.ts
@@ -120,13 +120,18 @@ const history_module: Module<HistoryState, RootState> = {
             if (!network?.explorerUrl) {
                 return
             }
-            let res = await getAliasChains()
-            if (res.chains) {
-                let chains = Object.entries(res.chains).map(([, value]) => {
-                    let v = value as Chain
-                    return { chainAlias: v.chainAlias, chainID: v.chainID }
-                })
-                state.chains = chains
+            try {
+                let res = await getAliasChains()
+                if (res.chains) {
+                    let chains = Object.entries(res.chains).map(([, value]) => {
+                        let v = value as Chain
+                        return { chainAlias: v.chainAlias, chainID: v.chainID }
+                    })
+                    state.chains = chains
+                }
+            } catch (e) {
+                console.error('Error fetching alias chains:', e)
+                return
             }
         },
     },

--- a/src/store/modules/network/network.ts
+++ b/src/store/modules/network/network.ts
@@ -190,7 +190,7 @@ const network_module: Module<NetworkState, RootState> = {
             dispatch('updateTxFee')
             dispatch('Accounts/updateKycStatus', null, { root: true })
             // Update tx history
-            this.dispatch('History/getAliasChains')
+            await this.dispatch('History/getAliasChains')
             await dispatch('Signavault/updateTransaction', undefined, { root: true })
             this.dispatch('History/updateTransactionHistory', null, { root: true })
 


### PR DESCRIPTION
### Summary

This PR addresses two important issues related to wallet and API interactions:

- 🪙 Fixes the rewards display when switching the active wallet
- 🔗 Resolves issues with the `getAliasChains` API call