### PR TITLE
feat: add feature flag to control undeposit functionality

### DIFF
--- a/src/components/CamOfferCard.vue
+++ b/src/components/CamOfferCard.vue
@@ -82,7 +82,7 @@
                             {{ cleanAvaxBN(reward.deposit.amount) }} {{ nativeAssetSymbol }}
                         </p>
                     </div>
-                    <div>
+                    <div v-if="!isUndepositDisabled">
                         <label>{{ $t('earn.rewards.active_earning.undepositable_amount') }}:</label>
                         <p class="reward">
                             {{ cleanAvaxBN(reward?.deposit?.unlockableAmount) }}
@@ -95,7 +95,7 @@
                             {{ cleanAvaxBN(reward.amountToClaim) }} {{ nativeAssetSymbol }}
                         </p>
                     </div>
-                    <div>
+                    <div v-if="!isUndepositDisabled">
                         <label>{{ $t('earn.rewards.active_earning.already_undeposited') }}:</label>
                         <p class="reward">
                             {{ cleanAvaxBN(reward?.deposit?.unlockedAmount) }}
@@ -115,7 +115,10 @@
                             {{ updateMultisigTxDetails() }} {{ nativeAssetSymbol }}
                         </p>
                     </div>
-                    <div class="reward_row" v-if="pendingUnlockAmount !== null">
+                    <div
+                        class="reward_row"
+                        v-if="pendingUnlockAmount !== null && !isUndepositDisabled"
+                    >
                         <label>{{ $t('earn.rewards.active_earning.initiated_undeposit') }}:</label>
                         <p class="reward">{{ pendingUnlockAmount }} {{ nativeAssetSymbol }}</p>
                     </div>
@@ -167,6 +170,7 @@ export default class CamOfferCard extends Vue {
     @Prop() readonly reward!: PlatformRewardDeposit
     @Prop() readonly treasuryRewards!: PlatformRewardTreasury
     @Prop() readonly pendingUndepositTx!: UndepositPendingTx | null
+    @Prop() readonly isUndepositDisabled!: boolean
 
     get isOffer() {
         return this.type === 'offer'

--- a/src/components/wallet/earn/DepositRewardCard.vue
+++ b/src/components/wallet/earn/DepositRewardCard.vue
@@ -4,9 +4,11 @@
         type="reward"
         :reward="reward"
         :pendingUndepositTx="pendingUndepositTx"
+        :isUndepositDisabled="isUndepositDisabled"
     >
         <div v-if="!isMultiSig" class="button_group">
             <undeposit-buttons
+                v-if="!isUndepositDisabled"
                 :reward="reward"
                 :pendingUndepositTx="pendingUndepositTx"
                 @updateDisclaimer="updateDisclaimer"
@@ -78,6 +80,7 @@
             </div>
             <div v-else class="button_group">
                 <undeposit-buttons
+                    v-if="!isUndepositDisabled"
                     :reward="reward"
                     :pendingUndepositTx="pendingUndepositTx"
                     @updateDisclaimer="updateDisclaimer"
@@ -128,7 +131,12 @@ import 'reflect-metadata'
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 
 import ModalClaimReward from '@/components/modals/ClaimRewardModal.vue'
-import { cleanAvaxBN, UndepositPendingTx } from '@/helpers/helper'
+import {
+    cleanAvaxBN,
+    getNodeVersion,
+    isVersionSupported,
+    UndepositPendingTx,
+} from '@/helpers/helper'
 import { PlatformRewardDeposit } from '@/store/modules/platform/types'
 
 import { bintools } from '@/AVA'
@@ -146,6 +154,7 @@ import { ModelMultisigTxOwner } from '@c4tplatform/signavaultjs'
 import ModalAbortSigning from './ModalAbortSigning.vue'
 import ModalClaimDepositReward from './ModalClaimDepositReward.vue'
 import UndepositButtons from './UndepositButtons.vue'
+import { AvaNetwork } from '@/js/AvaNetwork'
 
 @Component({
     components: {
@@ -167,6 +176,7 @@ export default class DepositRewardCard extends Vue {
     helpers = this.globalHelper()
     signedclaimedAmount: BN = new BN(0)
     disclaimerDisplay: boolean = false
+    nodeVersion: string | null = null
     // signedDepositID: string = ''
     @Prop() reward!: PlatformRewardDeposit
     @Prop() pendingUndepositTx!: UndepositPendingTx
@@ -194,10 +204,12 @@ export default class DepositRewardCard extends Vue {
         this.disclaimerDisplay = value
     }
 
-    created() {
+    async created() {
         this.intervalID = setInterval(() => {
             this.updateNow()
         }, 2000)
+
+        await this.checkNodeVersion()
     }
 
     destroyed() {
@@ -210,6 +222,31 @@ export default class DepositRewardCard extends Vue {
 
     get unlockableAmount(): BN {
         return this.reward.deposit.unlockableAmount
+    }
+
+    get isUndepositDisabled(): boolean {
+        if (!this.nodeVersion || this.nodeVersion === 'timeout') return true
+        return !isVersionSupported(this.nodeVersion)
+    }
+
+    get activeNetwork(): null | AvaNetwork {
+        return this.$store?.state?.Network?.selectedNetwork
+    }
+
+    @Watch('activeNetwork')
+    async checkNodeVersionOnNetworkChange() {
+        if (this.activeNetwork?.url) {
+            await this.checkNodeVersion()
+        }
+    }
+
+    async checkNodeVersion() {
+        try {
+            this.nodeVersion = await getNodeVersion(this.activeNetwork?.url as string)
+        } catch (error) {
+            console.error('Failed to check node version:', error)
+            this.nodeVersion = null
+        }
     }
 
     get activeWallet(): WalletType {

--- a/src/helpers/helper.ts
+++ b/src/helpers/helper.ts
@@ -13,12 +13,52 @@ import { MultisigTx as SignavaultTx } from '@/store/modules/signavault/types'
 
 import { Buffer, BN } from '@c4tplatform/caminojs/dist'
 import createHash from 'create-hash'
+import axios from 'axios'
 
 export interface UndepositPendingTx {
     hasSufficientUnlocked: boolean
     amountToUndeposit: BN
     depositTxIDs: string[]
     pendingTx: SignavaultTx
+}
+
+export function compareVersions(version1: string, version2: string): number {
+    const v1Parts = version1.split('.').map(Number)
+    const v2Parts = version2.split('.').map(Number)
+
+    for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
+        const v1Part = v1Parts[i] || 0
+        const v2Part = v2Parts[i] || 0
+
+        if (v1Part > v2Part) return 1
+        if (v1Part < v2Part) return -1
+    }
+
+    return 0
+}
+
+export function isVersionSupported(version: string): boolean {
+    const minVersion = '1.2.0'
+    return compareVersions(version, minVersion) >= 0
+}
+
+export async function getNodeVersion(url: string, credential = false): Promise<string | null> {
+    try {
+        const response = await axios.post(
+            `${url}/ext/info`,
+            { jsonrpc: '2.0', id: 1, method: 'info.getNodeVersion' },
+            { withCredentials: credential, timeout: 60000 }
+        )
+
+        const versionString = response.data.result.version
+        const versionMatch = versionString.match(/\/(\d+\.\d+\.\d+)/)
+        return versionMatch ? versionMatch[1] : null
+    } catch (error) {
+        if (axios.isAxiosError(error) && error.code === 'ECONNABORTED') {
+            return 'timeout'
+        }
+        return null
+    }
 }
 
 function bnToBig(val: BN, denomination = 0): Big {


### PR DESCRIPTION


### 🎯 **What**
Add feature flag to control undeposit functionality based on node version compatibility

### 🚀 **Why**
- Provides flexible control over undeposit feature availability
- Allows gradual rollout and easy disable/enable without code changes
- Prevents users from accessing unsupported functionality on incompatible nodes

### 🔧 **How**
- Added version comparison utilities for node compatibility checking
- Enhanced `DepositRewardCard` component with feature flag logic
- Added `isUndepositDisabled` computed property that:
  - Checks node version compatibility on component creation
  - Controls undeposit button visibility based on version support
  - Handles loading states and network errors gracefully
- Conditionally renders `undeposit-buttons` when feature is enabled

### ✅ **Changes**
- **New utilities**: Version checking and comparison functions
- **Modified component**: `DepositRewardCard.vue`
  - Feature flag implementation
  - Conditional rendering logic
  - Loading and error state handling
- **UX enhancement**: Dynamic UI based on node capabilities