### PR TITLE
Fix stale validator view after expiry & claim-rewards errors

### DIFF
--- a/src/components/modals/ClaimRewardModal.vue
+++ b/src/components/modals/ClaimRewardModal.vue
@@ -115,6 +115,8 @@ export default class ModalClaimReward extends Vue {
         await this.$store.dispatch('Platform/updateRewards')
     }
     async confirmClaim() {
+        // @ts-ignore
+        let { dispatchNotification } = this.globalHelper()
         const wallet: WalletType = this.$store.state.activeWallet
         const hrp = ava.getHRP()
         const rewardOwner = new OutputOwners(
@@ -147,6 +149,12 @@ export default class ModalClaimReward extends Vue {
                     msgText: 'Transaction Recorded.',
                 })
             } else {
+                const err = error instanceof Error ? error : new Error('Unknown error')
+                const errorMessage = err?.message
+                dispatchNotification({
+                    message: errorMessage,
+                    type: 'error',
+                })
                 console.error(error)
                 this.claimed = false
                 return

--- a/src/components/wallet/TopCards/BalanceCard/BalanceCard.vue
+++ b/src/components/wallet/TopCards/BalanceCard/BalanceCard.vue
@@ -9,7 +9,11 @@
                         class="spinner"
                         data-cy="spinner-balance"
                     ></Spinner>
-                    <button v-else @click="updateBalance" data-cy="btn-refresh-balance">
+                    <button
+                        v-else
+                        @click="updateBalanceAndValidators"
+                        data-cy="btn-refresh-balance"
+                    >
                         <v-icon>mdi-refresh</v-icon>
                     </button>
                 </div>
@@ -124,7 +128,6 @@ import { bnToBig } from '@/helpers/helper'
 import { priceDict } from '@/store/types'
 import { WalletNameType, WalletType } from '@/js/wallets/types'
 import UtxosBreakdownModal from '@/components/modals/UtxosBreakdown/UtxosBreakdownModal.vue'
-import { ava } from '@/AVA'
 
 @Component({
     components: {
@@ -147,8 +150,9 @@ export default class BalanceCard extends Vue {
         utxos_modal: UtxosBreakdownModal
     }
 
-    updateBalance(): void {
+    updateBalanceAndValidators(): void {
         this.$store.dispatch('updateBalances')
+        this.$store.dispatch('Platform/updateValidators')
     }
 
     showUTXOsModal() {

--- a/src/components/wallet/earn/ModalClaimDepositReward.vue
+++ b/src/components/wallet/earn/ModalClaimDepositReward.vue
@@ -220,8 +220,10 @@ export default class ModalClaimDepositReward extends Vue {
                     this.claimed = 1
                 })
                 .catch((err) => {
+                    const error = err instanceof Error ? err : new Error('Unknown error')
+                    const errorMessage = error?.message
                     dispatchNotification({
-                        message: this.$t('notifications.something_went_wrong'),
+                        message: errorMessage,
                         type: 'error',
                     })
                     this.confiremedClaimedAmount = new BN(0)

--- a/src/components/wallet/earn/Validate/ModalClaimReward.vue
+++ b/src/components/wallet/earn/Validate/ModalClaimReward.vue
@@ -155,6 +155,12 @@ export default class ModalClaimReward extends Vue {
                 })
                 this.$emit('beforeCloseModal', false)
             } else {
+                const error = e instanceof Error ? e : new Error('Unknown error')
+                const errorMessage = error?.message
+                dispatchNotification({
+                    message: errorMessage,
+                    type: 'error',
+                })
                 this.claimed = false
             }
         }

--- a/src/views/wallet/Validator.vue
+++ b/src/views/wallet/Validator.vue
@@ -248,8 +248,9 @@ export default class Validator extends Vue {
         this.nodeInfo = val
     }
 
-    updateValidators() {
-        this.$store.dispatch('Platform/updateValidators')
+    async updateValidators() {
+        const updatingValidators = this.$store.dispatch('Platform/updateValidators')
+        return updatingValidators
     }
 
     activated() {
@@ -395,6 +396,7 @@ export default class Validator extends Vue {
     }
 
     async refresh() {
+        await this.updateValidators()
         if (this.tab == 'opt-rewards') {
             this.loading = true
             await this.$store.dispatch('Signavault/updateTransaction')
@@ -412,7 +414,6 @@ export default class Validator extends Vue {
             this.$store.dispatch('updateBalances')
             if (this.isMultisignTx) await this.getPendingTransaction()
             await this.evaluateCanRegisterNode()
-            await this.updateValidators()
             await this.$store.dispatch('Signavault/updateTransaction')
             if (this.nodeInfo) await this.getInformationValidator()
             this.loading = false


### PR DESCRIPTION
This PR addresses two issues in the validator flows:

1. Validator page stale after validation period expiry
    Previously, when a node’s validation period ended, the validator page still showed the expired validator with an empty “remaining time” field. Refreshing or switching pages didn’t help; only logout/login fixed it.
2. No visible feedback when claiming rewards with 0 CAM on P-Chain
The claim action failed silently in the UI (only logged in console).
Fix: Added notifications to display the correct error message when the claim fails.